### PR TITLE
Timeline improvements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import "./styles/components.css";
 import { TitleBar } from "./components/layout/TitleBar";
 import { ProjectPanel } from "./components/layout/ProjectPanel";
 import { VideoPanel } from "./components/layout/VideoPanel";
+import { TransportBar } from "./components/layout/TransportBar";
 import { CaptionPanel, commitActiveEdit, cancelActiveEdit } from "./components/layout/CaptionPanel";
 import { Timeline } from "./components/layout/Timeline";
 import { isPlaying, undo, redo, canUndo, canRedo, undoDescription, redoDescription, isDirty, profiles, sidecarStatus, daemonStatus, project, projectPath, resetHistory, isBatchRunning, flushOpenClipView } from "./store/app";
@@ -442,7 +443,10 @@ export function App() {
         <TitleBar />
         <div class="main-panels">
           <ProjectPanel />
-          <VideoPanel />
+          <div class="video-column">
+            <VideoPanel />
+            <TransportBar />
+          </div>
           <CaptionPanel />
         </div>
         <Timeline />

--- a/src/components/layout/CaptionPanel.tsx
+++ b/src/components/layout/CaptionPanel.tsx
@@ -5,6 +5,7 @@ import {
   selectedMediaId,
   selectedCaptionIndex,
   playbackTime,
+  revealCaptionTick,
   project,
   activeProfile,
   pushHistory,
@@ -468,6 +469,7 @@ export function CaptionPanel() {
                   editingIndex.value = null;
                   selectedCaptionIndex.value = block.index;
                   playbackTime.value = block.start;
+                  revealCaptionTick.value++; // reveal in the timeline, even if already active
                 }}
                 onDblClick={() => {
                   selectedCaptionIndex.value = block.index;

--- a/src/components/layout/Timeline.tsx
+++ b/src/components/layout/Timeline.tsx
@@ -138,6 +138,7 @@ export function Timeline() {
     painterRef.current = painter;
     painter.setLayoutDuration(duration);
     painter.setStyle(waveStyle);
+    painter.setColor(getComputedStyle(canvas).getPropertyValue("--tl-waveform").trim() || "#374151");
 
     const flog = (m: string) =>
       invoke("frontend_log", { message: `[waveform] ${m}` }).catch(() => {});

--- a/src/components/layout/Timeline.tsx
+++ b/src/components/layout/Timeline.tsx
@@ -5,7 +5,7 @@ import { useSignalEffect, signal } from "@preact/signals";
 import { invoke } from "@tauri-apps/api/core";
 import { getCachedPeaks, cachePeaks, desiredBinsPerSec } from "../../lib/peaks-cache";
 import { createWaveformPainter, type WaveformStyle } from "../../lib/waveform";
-import { frameStep, nextBoundary } from "../../lib/playhead";
+import { frameStep, nextBoundary, clampStart, clampEnd } from "../../lib/playhead";
 import {
   selectedMedia,
   selectedCaptionIndex,
@@ -416,17 +416,19 @@ export function Timeline() {
   // Live-update caption timing during drag (no history entry yet)
   const handleResizeLive = (index: number, newStart: number, newEnd: number) => {
     const proj = project.value;
-    if (!proj || !media) return;
+    const med = selectedMedia.value; // live, not the render-time const — the
+    const f = med?.fps ?? activeProfile.value.timing.defaultFps; // [/] keydown
+    if (!proj || !med) return; // handler reuses this from a mount-time closure
     project.value = {
       ...proj,
       media: proj.media.map((m) =>
-        m.id !== media.id ? m : {
+        m.id !== med.id ? m : {
           ...m,
           captions: m.captions.map((c) =>
             c.index !== index ? c : {
               ...c,
               start: Math.max(0, newStart),
-              end: Math.max(newStart + 1 / fps, newEnd),
+              end: Math.max(newStart + 1 / f, newEnd),
             }
           ),
         }
@@ -524,6 +526,32 @@ export function Timeline() {
         if (m) for (const c of m.captions) bounds.push(c.start, c.end);
         const target = nextBoundary(playbackTime.peek(), bounds, e.key === "ArrowDown" ? 1 : -1);
         if (target !== undefined) playbackTime.value = Math.max(0, Math.min(dur, target));
+      } else if ((e.key === "[" || e.key === "]") && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        // Trim the selected caption's in ([) / out (]) point to the playhead —
+        // same clamp + commit path as dragging its resize handle. Reads live.
+        e.preventDefault();
+        const m = selectedMedia.value;
+        const idx = selectedCaptionIndex.value;
+        if (!m || idx == null) return;
+        const pos = m.captions.findIndex((c) => c.index === idx);
+        if (pos < 0) return;
+        const cap = m.captions[pos];
+        const f = m.fps ?? activeProfile.value.timing.defaultFps;
+        const dur = mediaDuration.peek() || (m.captions.length ? m.captions[m.captions.length - 1].end : 0);
+        const minDur = 1 / f;
+        const t = playbackTime.peek();
+        if (e.key === "[") {
+          const prevEnd = pos > 0 ? m.captions[pos - 1].end : null;
+          const newStart = snapToFrame(clampStart(t, prevEnd, cap.end, minDur), f);
+          if (newStart === cap.start) return; // clamped to no change — skip the edit
+          handleResizeLive(idx, newStart, cap.end);
+        } else {
+          const nextStart = pos < m.captions.length - 1 ? m.captions[pos + 1].start : null;
+          const newEnd = snapToFrame(clampEnd(t, cap.start, nextStart, dur, minDur), f);
+          if (newEnd === cap.end) return; // clamped to no change — skip the edit
+          handleResizeLive(idx, cap.start, newEnd);
+        }
+        if (project.value) pushHistory(project.value, e.key === "[" ? "Trim caption in" : "Trim caption out");
       }
     };
     document.addEventListener("keydown", handler);
@@ -777,7 +805,6 @@ function ResizableCaptionBlock({
       if (edge === "left") {
         let rawTime = originStart + dx * secPerPx;
         let snapped: number | null = null;
-        const lowerBound = prevEnd ?? 0;
         if (snapEnabled) {
           // Dead zone + snap only when there's an actual preceding caption;
           // at the media start (prevEnd === null) the first caption can begin
@@ -795,8 +822,8 @@ function ResizableCaptionBlock({
           }
         }
         const newStart = snapped !== null
-          ? Math.max(lowerBound, Math.min(snapped, originEnd - minDuration))
-          : snapToFrame(Math.max(lowerBound, Math.min(rawTime, originEnd - minDuration)), fps);
+          ? clampStart(snapped, prevEnd, originEnd, minDuration)
+          : snapToFrame(clampStart(rawTime, prevEnd, originEnd, minDuration), fps);
         resizeIndicator.value = newStart;
         resizeSnapped.value = snapped !== null;
         onResizeLive(block.index, newStart, originEnd);
@@ -804,7 +831,6 @@ function ResizableCaptionBlock({
       } else {
         let rawTime = originEnd + dx * secPerPx;
         let snapped: number | null = null;
-        const upperBound = nextStart ?? duration;
         if (snapEnabled) {
           // Dead zone + snap only when there's an actual following caption;
           // at the media end (nextStart === null) the last caption can run
@@ -822,8 +848,8 @@ function ResizableCaptionBlock({
           }
         }
         const newEnd = snapped !== null
-          ? Math.max(originStart + minDuration, Math.min(snapped, upperBound))
-          : snapToFrame(Math.max(originStart + minDuration, Math.min(rawTime, upperBound)), fps);
+          ? clampEnd(snapped, originStart, nextStart, duration, minDuration)
+          : snapToFrame(clampEnd(rawTime, originStart, nextStart, duration, minDuration), fps);
         resizeIndicator.value = newEnd;
         resizeSnapped.value = snapped !== null;
         onResizeLive(block.index, originStart, newEnd);

--- a/src/components/layout/Timeline.tsx
+++ b/src/components/layout/Timeline.tsx
@@ -5,12 +5,13 @@ import { useSignalEffect, signal, batch } from "@preact/signals";
 import { invoke } from "@tauri-apps/api/core";
 import { getCachedPeaks, cachePeaks, desiredBinsPerSec } from "../../lib/peaks-cache";
 import { createWaveformPainter, type WaveformStyle } from "../../lib/waveform";
-import { frameStep, nextBoundary, clampStart, clampEnd, computeTrim, computeRoll } from "../../lib/playhead";
+import { nextBoundary, clampStart, clampEnd, computeTrim, computeRoll } from "../../lib/playhead";
 import {
   selectedMedia,
   selectedCaptionIndex,
   playbackTime,
   isPlaying,
+  stepPlayhead,
   scrubbing,
   revealCaptionTick,
   zoomLevel,
@@ -503,16 +504,9 @@ export function Timeline() {
         e.preventDefault();
         zoomAroundPlayhead(1 / 1.5);
       } else if ((e.key === "ArrowLeft" || e.key === "ArrowRight") && !e.ctrlKey && !e.metaKey && !e.altKey) {
-        // Step the playhead one frame (Premiere-style). fps/duration read live —
-        // this effect's closure is mount-time, so the component consts are stale.
+        // Step the playhead one frame, paused (Premiere-style).
         e.preventDefault();
-        const m = selectedMedia.value;
-        const f = m?.fps ?? activeProfile.value.timing.defaultFps;
-        const dur = mediaDuration.peek() || (m?.captions.length ? m.captions[m.captions.length - 1].end : 0);
-        if (!f || !dur) return;
-        isPlaying.value = false; // stepping is a paused review action
-        const next = frameStep(playbackTime.peek(), f, e.key === "ArrowRight" ? 1 : -1);
-        playbackTime.value = Math.max(0, Math.min(dur, next));
+        stepPlayhead(e.key === "ArrowRight" ? 1 : -1);
       } else if ((e.key === "ArrowUp" || e.key === "ArrowDown") && !e.ctrlKey && !e.metaKey && !e.altKey) {
         // Jump to the adjacent region boundary: every caption start/end, plus the
         // timeline start (0) and end. Down → next, Up → previous.

--- a/src/components/layout/Timeline.tsx
+++ b/src/components/layout/Timeline.tsx
@@ -1,10 +1,10 @@
 import { useRef, useEffect } from "preact/hooks";
 import type { ComponentChildren } from "preact";
-import { SkipBackIcon as SkipBack, PlayIcon as Play, PauseIcon as Pause, MinusIcon as Minus, PlusIcon as Plus, MagnetIcon as Magnet } from "@phosphor-icons/react";
+import { SkipBackIcon as SkipBack, PlayIcon as Play, PauseIcon as Pause, MinusIcon as Minus, PlusIcon as Plus, MagnetIcon as Magnet, WaveSineIcon as WaveSine, WaveformIcon as Waveform } from "@phosphor-icons/react";
 import { useSignalEffect, signal } from "@preact/signals";
 import { invoke } from "@tauri-apps/api/core";
 import { getCachedPeaks, cachePeaks, desiredBinsPerSec } from "../../lib/peaks-cache";
-import { createWaveformPainter } from "../../lib/waveform";
+import { createWaveformPainter, type WaveformStyle } from "../../lib/waveform";
 import {
   selectedMedia,
   selectedCaptionIndex,
@@ -33,6 +33,8 @@ const VALID_MODES: TimecodeCycle[] = ["time", "smpte", "frames"];
 const stored = localStorage.getItem("codfish:timecodeMode") as TimecodeCycle;
 const timecodeMode = signal<TimecodeCycle>(VALID_MODES.includes(stored) ? stored : "time");
 const snapEnabled = signal(true);
+const storedWaveStyle = localStorage.getItem("codfish:waveformStyle");
+const waveformStyle = signal<WaveformStyle>(storedWaveStyle === "bars" ? "bars" : "continuous");
 const resizeIndicator = signal<number | null>(null);
 const resizeSnapped = signal(false);
 // Outer viewport width, mirrored into a signal so the virtualized ruler can
@@ -101,6 +103,7 @@ export function Timeline() {
     ? media.captions[media.captions.length - 1].end
     : 0;
   const duration = mediaDuration.value || waveformAudioDuration.value || captionDuration;
+  const waveStyle = waveformStyle.value;
 
   // Init / reinit the waveform painter when media changes
   useEffect(() => {
@@ -134,6 +137,7 @@ export function Timeline() {
     });
     painterRef.current = painter;
     painter.setLayoutDuration(duration);
+    painter.setStyle(waveStyle);
 
     const flog = (m: string) =>
       invoke("frontend_log", { message: `[waveform] ${m}` }).catch(() => {});
@@ -205,6 +209,12 @@ export function Timeline() {
   useEffect(() => {
     painterRef.current?.setLayoutDuration(duration);
   }, [duration]);
+
+  // Push the chosen render style to the painter (same post-render pattern as
+  // duration, so it lands on the current painter after a media switch).
+  useEffect(() => {
+    painterRef.current?.setStyle(waveStyle);
+  }, [waveStyle]);
 
   // Scroll- and zoom-driven repaints are owned by the painter itself: it
   // listens to the outer container's scroll and observes the waveform row
@@ -492,6 +502,18 @@ export function Timeline() {
           data-tooltip={snapEnabled.value ? "Gap snapping on (G)" : "Gap snapping off (G)"}
         >
           <Magnet size={14} />
+        </button>
+
+        <button
+          class="timeline-btn"
+          onClick={() => {
+            const next: WaveformStyle = waveformStyle.value === "continuous" ? "bars" : "continuous";
+            waveformStyle.value = next;
+            localStorage.setItem("codfish:waveformStyle", next);
+          }}
+          data-tooltip={waveformStyle.value === "continuous" ? "Waveform: continuous" : "Waveform: bars"}
+        >
+          {waveformStyle.value === "continuous" ? <WaveSine size={14} /> : <Waveform size={14} />}
         </button>
 
         <ZoomControls scrollRef={scrollRef} zoomAroundPlayhead={zoomAroundPlayhead} />

--- a/src/components/layout/Timeline.tsx
+++ b/src/components/layout/Timeline.tsx
@@ -5,7 +5,7 @@ import { useSignalEffect, signal } from "@preact/signals";
 import { invoke } from "@tauri-apps/api/core";
 import { getCachedPeaks, cachePeaks, desiredBinsPerSec } from "../../lib/peaks-cache";
 import { createWaveformPainter, type WaveformStyle } from "../../lib/waveform";
-import { frameStep, nextBoundary, clampStart, clampEnd } from "../../lib/playhead";
+import { frameStep, nextBoundary, clampStart, clampEnd, computeTrim } from "../../lib/playhead";
 import {
   selectedMedia,
   selectedCaptionIndex,
@@ -527,30 +527,17 @@ export function Timeline() {
         const target = nextBoundary(playbackTime.peek(), bounds, e.key === "ArrowDown" ? 1 : -1);
         if (target !== undefined) playbackTime.value = Math.max(0, Math.min(dur, target));
       } else if ((e.key === "[" || e.key === "]") && !e.ctrlKey && !e.metaKey && !e.altKey) {
-        // Trim the selected caption's in ([) / out (]) point to the playhead —
-        // same clamp + commit path as dragging its resize handle. Reads live.
+        // Trim the selected caption's in ([) / out (]) edge to the playhead, then
+        // commit through the same path the resize-handle drag uses. Reads live.
         e.preventDefault();
         const m = selectedMedia.value;
         const idx = selectedCaptionIndex.value;
         if (!m || idx == null) return;
-        const pos = m.captions.findIndex((c) => c.index === idx);
-        if (pos < 0) return;
-        const cap = m.captions[pos];
         const f = m.fps ?? activeProfile.value.timing.defaultFps;
         const dur = mediaDuration.peek() || (m.captions.length ? m.captions[m.captions.length - 1].end : 0);
-        const minDur = 1 / f;
-        const t = playbackTime.peek();
-        if (e.key === "[") {
-          const prevEnd = pos > 0 ? m.captions[pos - 1].end : null;
-          const newStart = snapToFrame(clampStart(t, prevEnd, cap.end, minDur), f);
-          if (newStart === cap.start) return; // clamped to no change — skip the edit
-          handleResizeLive(idx, newStart, cap.end);
-        } else {
-          const nextStart = pos < m.captions.length - 1 ? m.captions[pos + 1].start : null;
-          const newEnd = snapToFrame(clampEnd(t, cap.start, nextStart, dur, minDur), f);
-          if (newEnd === cap.end) return; // clamped to no change — skip the edit
-          handleResizeLive(idx, cap.start, newEnd);
-        }
+        const trimmed = computeTrim(m.captions, idx, e.key === "[" ? "in" : "out", playbackTime.peek(), f, dur);
+        if (!trimmed) return; // caption not found, or clamped to no change
+        handleResizeLive(idx, trimmed.start, trimmed.end);
         if (project.value) pushHistory(project.value, e.key === "[" ? "Trim caption in" : "Trim caption out");
       }
     };

--- a/src/components/layout/Timeline.tsx
+++ b/src/components/layout/Timeline.tsx
@@ -11,6 +11,7 @@ import {
   playbackTime,
   isPlaying,
   scrubbing,
+  revealCaptionTick,
   zoomLevel,
   timelineScroll,
   mediaDuration,
@@ -254,20 +255,41 @@ export function Timeline() {
     return () => cancelAnimationFrame(raf);
   }, [media?.id]);
 
-  // Auto-scroll to keep playhead in view during playback
+  // Auto-scroll to keep the playhead in view when it MOVES on its own — during
+  // playback, or on a seek (selecting a caption in the panel, including
+  // re-selecting an off-screen active one). NOT while manually scrubbing/clicking
+  // the timeline: there the playhead is at the pointer and already visible, so a
+  // click shouldn't jump the view. Keyed on playbackTime (+ a reveal tick);
+  // mediaDuration/zoom/scrubbing are peeked so a settling duration, a zoom step
+  // (which has its own playhead-anchored scroll), or the scrub-release edge don't
+  // trigger it. Skipped at fit zoom and on a clip switch (the [media?.id] effect
+  // restores the remembered scroll there; following the playhead would clobber it).
+  const lastAutoScrollClip = useRef<string | undefined>(undefined);
   useSignalEffect(() => {
     const scroll = scrollRef.current;
     const time = playbackTime.value;
-    const dur = mediaDuration.value;
-    const isCurrentlyPlaying = isPlaying.value;
-    const zoom = zoomLevel.value;
+    const clipId = selectedMedia.value?.id;
+    const dur = mediaDuration.peek();
+    const zoom = zoomLevel.peek();
+    // Subscribe to panel reveal requests: re-clicking an active caption bumps this
+    // so we re-scroll to it even though its start is already the playhead.
+    void revealCaptionTick.value;
 
-    if (!scroll || !dur || zoom <= 1 || !isCurrentlyPlaying) return;
+    // Record the clip on every pass so a switch is detected exactly once — at the
+    // switch itself — even when we bail below because the duration hasn't loaded
+    // yet. Recording only after the bail would defer "switched" onto the user's
+    // first seek in the new clip and swallow its scroll. On the switch pass we
+    // skip: the [media?.id] effect is restoring the remembered scroll.
+    const switched = clipId !== lastAutoScrollClip.current;
+    lastAutoScrollClip.current = clipId;
 
-    const fraction = time / dur;
+    // Skipped while scrubbing/clicking the timeline (peeked, so the release edge
+    // doesn't fire a scroll either) — the playhead is at the pointer, in view.
+    if (!scroll || !dur || zoom <= 1 || switched || scrubbing.peek()) return;
+
     const totalWidth = scroll.scrollWidth;
     const visibleWidth = scroll.clientWidth;
-    const playheadPx = fraction * totalWidth;
+    const playheadPx = (time / dur) * totalWidth;
     const scrollLeft = scroll.scrollLeft;
 
     if (
@@ -324,25 +346,59 @@ export function Timeline() {
     if (e.button !== 0 || !duration) return;
     const el = e.currentTarget as HTMLElement;
 
+    const scroll = scrollRef.current;
     scrubbing.value = true; // pause per-action view persistence until release
     const wasPlaying = isPlaying.peek();
     if (wasPlaying) isPlaying.value = false;
 
-    const seek = (ev: MouseEvent) => {
+    const seekToClientX = (clientX: number) => {
       const rect = el.getBoundingClientRect();
-      const fraction = (ev.clientX - rect.left) / rect.width;
+      const fraction = (clientX - rect.left) / rect.width;
       playbackTime.value = Math.max(0, Math.min(duration, fraction * duration));
     };
 
-    seek(e);
+    seekToClientX(e.clientX);
 
-    const onMove = (ev: MouseEvent) => seek(ev);
+    // Edge-pan: once you've started dragging, holding the pointer near a viewport
+    // edge scrolls the timeline that way (and keeps seeking under the pointer) so
+    // you can scrub past what's visible. Speed ramps with how deep into the edge
+    // zone the pointer is, so it stays gentle; a plain click never pans (the
+    // `dragged` gate), and it stops at the content ends.
+    const startX = e.clientX;
+    let lastClientX = e.clientX;
+    let dragged = false;
+    let raf = 0;
+    const EDGE = 48; // px from each viewport edge that triggers panning
+    const MAX_SPEED = 16; // px/frame at the very edge
+    const pan = () => {
+      raf = requestAnimationFrame(pan);
+      if (!dragged || !scroll || zoomLevel.peek() <= 1) return;
+      const rect = scroll.getBoundingClientRect();
+      const x = lastClientX - rect.left;
+      let delta = 0;
+      if (x < EDGE) delta = -((EDGE - x) / EDGE) * MAX_SPEED;
+      else if (x > rect.width - EDGE) delta = ((x - (rect.width - EDGE)) / EDGE) * MAX_SPEED;
+      if (!delta) return;
+      const max = scroll.scrollWidth - scroll.clientWidth;
+      const next = Math.max(0, Math.min(max, scroll.scrollLeft + delta));
+      if (next === scroll.scrollLeft) return; // already at an end
+      scroll.scrollLeft = next;
+      seekToClientX(lastClientX); // keep the playhead under the held pointer
+    };
+
+    const onMove = (ev: MouseEvent) => {
+      if (Math.abs(ev.clientX - startX) > 4) dragged = true;
+      lastClientX = ev.clientX;
+      seekToClientX(ev.clientX);
+    };
     const onUp = () => {
+      cancelAnimationFrame(raf);
       window.removeEventListener("mousemove", onMove);
       window.removeEventListener("mouseup", onUp);
       if (wasPlaying) isPlaying.value = true;
       scrubbing.value = false; // landed — the persist effect saves the spot (if paused)
     };
+    raf = requestAnimationFrame(pan);
     window.addEventListener("mousemove", onMove);
     window.addEventListener("mouseup", onUp);
   };

--- a/src/components/layout/Timeline.tsx
+++ b/src/components/layout/Timeline.tsx
@@ -1,6 +1,6 @@
 import { useRef, useEffect } from "preact/hooks";
 import type { ComponentChildren } from "preact";
-import { SkipBackIcon as SkipBack, PlayIcon as Play, PauseIcon as Pause, MinusIcon as Minus, PlusIcon as Plus, MagnetIcon as Magnet, WaveSineIcon as WaveSine, WaveformIcon as Waveform, CrosshairIcon as Crosshair } from "@phosphor-icons/react";
+import { MinusIcon as Minus, PlusIcon as Plus, MagnetIcon as Magnet, WaveSineIcon as WaveSine, WaveformIcon as Waveform, CrosshairIcon as Crosshair } from "@phosphor-icons/react";
 import { useSignalEffect, signal, batch } from "@preact/signals";
 import { invoke } from "@tauri-apps/api/core";
 import { getCachedPeaks, cachePeaks, desiredBinsPerSec } from "../../lib/peaks-cache";
@@ -83,7 +83,6 @@ function waitForMediaDuration(timeoutMs: number): Promise<number | null> {
 
 export function Timeline() {
   const media = selectedMedia.value;
-  const playing = isPlaying.value;
   const profileDefaultFps = activeProfile.value.timing.defaultFps;
   const effectiveFps = media?.fps ?? profileDefaultFps;
   const fpsIsDetected = media != null && media.fps != null;
@@ -564,22 +563,11 @@ export function Timeline() {
 
   return (
     <div class="timeline">
-      {/* Transport controls — only shown with a clip loaded; every control here
-          acts on the active media, so there's nothing to operate on otherwise. */}
+      {/* Timeline toolbar — only with a clip loaded: the timecode/fps readout on
+          the left, view tools (snap, follow, waveform, zoom) on the right.
+          Playback transport lives under the video — see <TransportBar />. */}
       {media && (
-      <div class="timeline-transport">
-        <button
-          class="timeline-btn"
-          onClick={() => { playbackTime.value = 0; }}
-          data-tooltip="Go to start"
-        ><SkipBack size={14} weight="fill" /></button>
-        <button
-          class="timeline-btn timeline-btn--play"
-          onClick={() => { isPlaying.value = !playing; }}
-          data-tooltip={playing ? "Pause" : "Play"}
-        >
-          {playing ? <Pause size={14} weight="fill" /> : <Play size={14} weight="fill" />}
-        </button>
+      <div class="timeline-toolbar">
         <span class="timeline-mode-label">
           {timecodeMode.value === "time" && "Time"}
           {timecodeMode.value === "smpte" && (media?.dropFrame ? "SMPTE DF" : "SMPTE")}
@@ -964,7 +952,7 @@ function TimelinePlayhead({ duration }: { duration: number }) {
 }
 
 /** Same isolation pattern as TimelinePlayhead — owns the per-tick
- *  playbackTime read so the surrounding transport bar stays static. */
+ *  playbackTime read so the surrounding timeline toolbar stays static. */
 function TransportTimecode({ mode, fps, duration }: {
   mode: DisplayMode;
   fps: number;
@@ -1042,7 +1030,7 @@ function ScrollInner({ children }: { children: ComponentChildren }) {
 }
 
 /** Reads zoomLevel locally so zoom steps re-render three buttons, not the
- *  whole transport bar. */
+ *  whole timeline toolbar. */
 function ZoomControls({ scrollRef, zoomAroundPlayhead }: {
   scrollRef: { current: HTMLDivElement | null };
   zoomAroundPlayhead: (factor: number) => void;

--- a/src/components/layout/Timeline.tsx
+++ b/src/components/layout/Timeline.tsx
@@ -1,11 +1,11 @@
 import { useRef, useEffect } from "preact/hooks";
 import type { ComponentChildren } from "preact";
 import { SkipBackIcon as SkipBack, PlayIcon as Play, PauseIcon as Pause, MinusIcon as Minus, PlusIcon as Plus, MagnetIcon as Magnet, WaveSineIcon as WaveSine, WaveformIcon as Waveform, CrosshairIcon as Crosshair } from "@phosphor-icons/react";
-import { useSignalEffect, signal } from "@preact/signals";
+import { useSignalEffect, signal, batch } from "@preact/signals";
 import { invoke } from "@tauri-apps/api/core";
 import { getCachedPeaks, cachePeaks, desiredBinsPerSec } from "../../lib/peaks-cache";
 import { createWaveformPainter, type WaveformStyle } from "../../lib/waveform";
-import { frameStep, nextBoundary, clampStart, clampEnd, computeTrim } from "../../lib/playhead";
+import { frameStep, nextBoundary, clampStart, clampEnd, computeTrim, computeRoll } from "../../lib/playhead";
 import {
   selectedMedia,
   selectedCaptionIndex,
@@ -437,8 +437,8 @@ export function Timeline() {
   };
 
   // Commit caption timing after drag ends → push to undo history
-  const handleResizeCommit = () => {
-    if (project.value) pushHistory(project.value, "Resize caption");
+  const handleResizeCommit = (label = "Resize caption") => {
+    if (project.value) pushHistory(project.value, label);
   };
 
   // Zoom in/out keeping the playhead visually stationary.
@@ -539,6 +539,23 @@ export function Timeline() {
         if (!trimmed) return; // caption not found, or clamped to no change
         handleResizeLive(idx, trimmed.start, trimmed.end);
         if (project.value) pushHistory(project.value, e.key === "[" ? "Trim caption in" : "Trim caption out");
+      } else if ((e.key === "{" || e.key === "}") && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        // Rolling edit: { (Shift+[) rolls the cut on the selected caption's IN
+        // side, } (Shift+]) the OUT side — moving BOTH flanking edges to the
+        // playhead at once. Only fires when that boundary is shared (touching);
+        // a gapped edge has no single cut to roll, so it's a no-op.
+        e.preventDefault();
+        const m = selectedMedia.value;
+        const idx = selectedCaptionIndex.value;
+        if (!m || idx == null) return;
+        const f = m.fps ?? activeProfile.value.timing.defaultFps;
+        const roll = computeRoll(m.captions, idx, e.key === "{" ? "in" : "out", playbackTime.peek(), f);
+        if (!roll) return; // no shared boundary on that side, or no change
+        batch(() => {
+          handleResizeLive(roll.left.index, roll.left.start, roll.left.end);
+          handleResizeLive(roll.right.index, roll.right.start, roll.right.end);
+        });
+        if (project.value) pushHistory(project.value, "Roll edit");
       }
     };
     document.addEventListener("keydown", handler);
@@ -689,8 +706,8 @@ export function Timeline() {
                     block={block}
                     duration={duration}
                     fps={effectiveFps}
-                    prevEnd={media.captions[i - 1]?.end ?? null}
-                    nextStart={media.captions[i + 1]?.start ?? null}
+                    prev={media.captions[i - 1] ?? null}
+                    next={media.captions[i + 1] ?? null}
                     snapEnabled={snapEnabled.value}
                     minGap={minGap}
                     blocksRowRef={blocksRowRef}
@@ -724,8 +741,8 @@ function ResizableCaptionBlock({
   block,
   duration,
   fps,
-  prevEnd,
-  nextStart,
+  prev,
+  next,
   snapEnabled,
   minGap,
   blocksRowRef,
@@ -740,8 +757,8 @@ function ResizableCaptionBlock({
   block: CaptionBlock;
   duration: number;
   fps: number;
-  prevEnd: number | null;
-  nextStart: number | null;
+  prev: CaptionBlock | null;
+  next: CaptionBlock | null;
   snapEnabled: boolean;
   minGap: number | null;
   blocksRowRef: { current: HTMLDivElement | null };
@@ -749,12 +766,18 @@ function ResizableCaptionBlock({
   playing: boolean;
   warnings: ValidationWarning[];
   onResizeLive: (index: number, start: number, end: number) => void;
-  onResizeCommit: () => void;
+  onResizeCommit: (label?: string) => void;
   onClick: () => void;
   onDblClick: () => void;
 }) {
   const left = (block.start / duration) * 100;
   const width = ((block.end - block.start) / duration) * 100;
+
+  // The trim/snap code works off the neighbours' adjacent edges; rolling also
+  // needs their far edges + indices, so the component takes the whole neighbour
+  // captions and derives the adjacent edges here.
+  const prevEnd = prev?.end ?? null;
+  const nextStart = next?.start ?? null;
 
   const hasStrict = warnings.some(w => w.strict);
   const hasFuzzy = warnings.some(w => !w.strict);
@@ -777,6 +800,22 @@ function ResizableCaptionBlock({
     const rowEl = blocksRowRef.current;
     if (!rowEl) return;
 
+    // Select the caption you grab — deterministically, here on mousedown, not via
+    // the post-drag click (which is suppressed below). The playhead is left where
+    // it is: a trim/roll targets the playhead, it shouldn't also move it.
+    selectedCaptionIndex.value = block.index;
+
+    // After a drag, the browser fires a synthetic `click` whose target is the
+    // common ancestor of the mousedown (this handle) and mouseup elements. When
+    // that resolves to the block it reaches the block's onClick, which seeks the
+    // playhead to the caption start and reselects — the intermittent jump the
+    // handle should never cause. Swallow that one click (capture phase).
+    const swallowClick = (ev: MouseEvent) => {
+      ev.stopPropagation();
+      ev.preventDefault();
+      document.removeEventListener("click", swallowClick, true);
+    };
+
     const rect = rowEl.getBoundingClientRect();
     const secPerPx = duration / rect.width;
     const minDuration = 1 / fps;
@@ -787,8 +826,36 @@ function ResizableCaptionBlock({
     let lastStart = originStart;
     let lastEnd = originEnd;
 
+    // Shift-drag a handle sitting on a shared boundary = rolling edit: move the
+    // cut between this caption and its neighbour, dragging both edges together.
+    // Decided at mousedown; a gapped edge has no shared cut, so it stays a trim.
+    const EPS = 1e-4;
+    const rolling = e.shiftKey && (
+      (edge === "left" && prev !== null && Math.abs(prev.end - originStart) < EPS) ||
+      (edge === "right" && next !== null && Math.abs(next.start - originEnd) < EPS)
+    );
+    if (rolling) e.preventDefault(); // don't let the shift-drag select page text
+
     const onMove = (ev: MouseEvent) => {
       const dx = ev.clientX - originX;
+      if (rolling) {
+        // The cut follows the cursor; computeRoll clamps it within the two
+        // captions (each keeps ≥ 1 frame), snaps to a frame, and reports both edges.
+        const rawCut = (edge === "left" ? originStart : originEnd) + dx * secPerPx;
+        const pair = edge === "left" ? [prev!, block] : [block, next!];
+        const roll = computeRoll(pair, block.index, edge === "left" ? "in" : "out", rawCut, fps);
+        if (roll) {
+          batch(() => {
+            onResizeLive(roll.left.index, roll.left.start, roll.left.end);
+            onResizeLive(roll.right.index, roll.right.start, roll.right.end);
+          });
+          const cut = roll.left.end; // === roll.right.start
+          resizeIndicator.value = cut;
+          resizeSnapped.value = false;
+          if (edge === "left") lastStart = cut; else lastEnd = cut;
+        }
+        return;
+      }
       if (edge === "left") {
         let rawTime = originStart + dx * secPerPx;
         let snapped: number | null = null;
@@ -849,9 +916,13 @@ function ResizableCaptionBlock({
       resizeSnapped.value = false;
       // Skip commit if the final snapped values land back on the origin —
       // a drag that snaps into its starting position produced no net change.
-      if (lastStart !== originStart || lastEnd !== originEnd) onResizeCommit();
+      if (lastStart !== originStart || lastEnd !== originEnd) onResizeCommit(rolling ? "Roll edit" : undefined);
       window.removeEventListener("mousemove", onMove);
       window.removeEventListener("mouseup", onUp);
+      // Eat the trailing click (registered now so it's live before the click
+      // fires); tidy the listener up next tick if no click follows.
+      document.addEventListener("click", swallowClick, true);
+      setTimeout(() => document.removeEventListener("click", swallowClick, true), 0);
     };
 
     window.addEventListener("mousemove", onMove);

--- a/src/components/layout/Timeline.tsx
+++ b/src/components/layout/Timeline.tsx
@@ -450,7 +450,9 @@ export function Timeline() {
 
   return (
     <div class="timeline">
-      {/* Transport controls */}
+      {/* Transport controls — only shown with a clip loaded; every control here
+          acts on the active media, so there's nothing to operate on otherwise. */}
+      {media && (
       <div class="timeline-transport">
         <button
           class="timeline-btn"
@@ -497,7 +499,7 @@ export function Timeline() {
         )}
 
         <button
-          class={`timeline-btn${snapEnabled.value ? " timeline-btn--active" : ""}`}
+          class={`timeline-btn timeline-tools-start${snapEnabled.value ? " timeline-btn--active" : ""}`}
           onClick={() => { snapEnabled.value = !snapEnabled.value; }}
           data-tooltip={snapEnabled.value ? "Gap snapping on (G)" : "Gap snapping off (G)"}
         >
@@ -518,6 +520,7 @@ export function Timeline() {
 
         <ZoomControls scrollRef={scrollRef} zoomAroundPlayhead={zoomAroundPlayhead} />
       </div>
+      )}
 
       {/* Track area */}
       <div class="timeline-track-area">

--- a/src/components/layout/Timeline.tsx
+++ b/src/components/layout/Timeline.tsx
@@ -1,10 +1,11 @@
 import { useRef, useEffect } from "preact/hooks";
 import type { ComponentChildren } from "preact";
-import { SkipBackIcon as SkipBack, PlayIcon as Play, PauseIcon as Pause, MinusIcon as Minus, PlusIcon as Plus, MagnetIcon as Magnet, WaveSineIcon as WaveSine, WaveformIcon as Waveform } from "@phosphor-icons/react";
+import { SkipBackIcon as SkipBack, PlayIcon as Play, PauseIcon as Pause, MinusIcon as Minus, PlusIcon as Plus, MagnetIcon as Magnet, WaveSineIcon as WaveSine, WaveformIcon as Waveform, CrosshairIcon as Crosshair } from "@phosphor-icons/react";
 import { useSignalEffect, signal } from "@preact/signals";
 import { invoke } from "@tauri-apps/api/core";
 import { getCachedPeaks, cachePeaks, desiredBinsPerSec } from "../../lib/peaks-cache";
 import { createWaveformPainter, type WaveformStyle } from "../../lib/waveform";
+import { frameStep, nextBoundary } from "../../lib/playhead";
 import {
   selectedMedia,
   selectedCaptionIndex,
@@ -19,6 +20,7 @@ import {
   pushHistory,
   activeProfile,
   playingCaptionIndex,
+  followPlayhead,
   warningsByCaption,
   isBatchRunning,
 } from "../../store/app";
@@ -499,6 +501,29 @@ export function Timeline() {
       } else if ((e.ctrlKey || e.metaKey) && (e.key === "-" || e.key === "_")) {
         e.preventDefault();
         zoomAroundPlayhead(1 / 1.5);
+      } else if ((e.key === "ArrowLeft" || e.key === "ArrowRight") && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        // Step the playhead one frame (Premiere-style). fps/duration read live —
+        // this effect's closure is mount-time, so the component consts are stale.
+        e.preventDefault();
+        const m = selectedMedia.value;
+        const f = m?.fps ?? activeProfile.value.timing.defaultFps;
+        const dur = mediaDuration.peek() || (m?.captions.length ? m.captions[m.captions.length - 1].end : 0);
+        if (!f || !dur) return;
+        isPlaying.value = false; // stepping is a paused review action
+        const next = frameStep(playbackTime.peek(), f, e.key === "ArrowRight" ? 1 : -1);
+        playbackTime.value = Math.max(0, Math.min(dur, next));
+      } else if ((e.key === "ArrowUp" || e.key === "ArrowDown") && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        // Jump to the adjacent region boundary: every caption start/end, plus the
+        // timeline start (0) and end. Down → next, Up → previous.
+        e.preventDefault();
+        const m = selectedMedia.value;
+        const dur = mediaDuration.peek() || (m?.captions.length ? m.captions[m.captions.length - 1].end : 0);
+        if (!dur) return;
+        isPlaying.value = false; // jumping is a paused review action
+        const bounds = [0, dur];
+        if (m) for (const c of m.captions) bounds.push(c.start, c.end);
+        const target = nextBoundary(playbackTime.peek(), bounds, e.key === "ArrowDown" ? 1 : -1);
+        if (target !== undefined) playbackTime.value = Math.max(0, Math.min(dur, target));
       }
     };
     document.addEventListener("keydown", handler);
@@ -564,6 +589,17 @@ export function Timeline() {
         </button>
 
         <button
+          class={`timeline-btn${followPlayhead.value ? " timeline-btn--active" : ""}`}
+          onClick={() => {
+            followPlayhead.value = !followPlayhead.value;
+            localStorage.setItem("codfish:followPlayhead", String(followPlayhead.value));
+          }}
+          data-tooltip={followPlayhead.value ? "Auto-select caption under playhead: on" : "Auto-select caption under playhead: off"}
+        >
+          <Crosshair size={14} />
+        </button>
+
+        <button
           class="timeline-btn"
           onClick={() => {
             const next: WaveformStyle = waveformStyle.value === "continuous" ? "bars" : "continuous";
@@ -591,7 +627,7 @@ export function Timeline() {
             <ScrollInner>
               {/* Ruler */}
               {duration > 0 && (
-                <RulerRow duration={duration} mode={smpteMode} fps={effectiveFps} />
+                <RulerRow duration={duration} mode={smpteMode} fps={effectiveFps} onMouseDown={handleWaveMouseDown} />
               )}
 
               {/* Waveform row — click to seek */}
@@ -864,10 +900,11 @@ function TransportTimecode({ mode, fps, duration }: {
  *  count scales with zoom — tens of thousands of divs rebuilt on every
  *  zoom step; with it, renders stay at a few dozen nodes and panning
  *  re-renders only this row. */
-function RulerRow({ duration, mode, fps }: {
+function RulerRow({ duration, mode, fps, onMouseDown }: {
   duration: number;
   mode: DisplayMode;
   fps: number;
+  onMouseDown: (e: MouseEvent) => void;
 }) {
   const zoom = zoomLevel.value;
   const scrollLeft = timelineScroll.value;
@@ -890,7 +927,7 @@ function RulerRow({ duration, mode, fps }: {
   }
 
   return (
-    <div class="timeline-ruler-row">
+    <div class="timeline-ruler-row" onMouseDown={onMouseDown}>
       {ticks.map(t => (
         <div
           key={t}

--- a/src/components/layout/Timeline.tsx
+++ b/src/components/layout/Timeline.tsx
@@ -483,7 +483,7 @@ export function Timeline() {
   // while blocked (update / batch generation) — document-level keydown isn't
   // caught by the inert app-shell.
   //   G            → toggle gap snap
-  //   Ctrl/Cmd +/- → zoom around playhead ("=" unshifted; "+"/"_" shifted/numpad)
+  //   +/-          → zoom around playhead ("=" unshifted; "+"/"_" shifted/numpad)
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (
@@ -497,10 +497,10 @@ export function Timeline() {
       if (e.key === "g" && !e.ctrlKey && !e.metaKey) {
         e.preventDefault();
         snapEnabled.value = !snapEnabled.value;
-      } else if ((e.ctrlKey || e.metaKey) && (e.key === "=" || e.key === "+")) {
+      } else if (e.key === "=" || e.key === "+") {
         e.preventDefault();
         zoomAroundPlayhead(1.5);
-      } else if ((e.ctrlKey || e.metaKey) && (e.key === "-" || e.key === "_")) {
+      } else if (e.key === "-" || e.key === "_") {
         e.preventDefault();
         zoomAroundPlayhead(1 / 1.5);
       } else if ((e.key === "ArrowLeft" || e.key === "ArrowRight") && !e.ctrlKey && !e.metaKey && !e.altKey) {
@@ -1035,7 +1035,7 @@ function ZoomControls({ scrollRef, zoomAroundPlayhead }: {
       <button
         class="timeline-btn timeline-btn--sm"
         onClick={() => zoomAroundPlayhead(1 / 1.5)}
-        data-tooltip="Zoom out (Ctrl/Cmd −, Ctrl/Cmd+Scroll)"
+        data-tooltip="Zoom out (− or Ctrl/Cmd+Scroll)"
         disabled={zoom <= 1}
       ><Minus size={12} /></button>
       <button
@@ -1051,7 +1051,7 @@ function ZoomControls({ scrollRef, zoomAroundPlayhead }: {
       <button
         class="timeline-btn timeline-btn--sm"
         onClick={() => zoomAroundPlayhead(1.5)}
-        data-tooltip="Zoom in (Ctrl/Cmd +, Ctrl/Cmd+Scroll)"
+        data-tooltip="Zoom in (+ or Ctrl/Cmd+Scroll)"
       ><Plus size={12} /></button>
     </div>
   );

--- a/src/components/layout/TransportBar.tsx
+++ b/src/components/layout/TransportBar.tsx
@@ -1,0 +1,63 @@
+import {
+  SkipBackIcon as SkipBack,
+  SkipForwardIcon as SkipForward,
+  CaretLineLeftIcon as StepBack,
+  CaretLineRightIcon as StepForward,
+  PlayIcon as Play,
+  PauseIcon as Pause,
+} from "@phosphor-icons/react";
+import { selectedMedia, isPlaying, playbackTime, mediaDuration, activeProfile } from "../../store/app";
+import { frameStep } from "../../lib/playhead";
+
+/**
+ * Playback transport — a strip docked under the video preview: go to start,
+ * frame-step back/forward, and play/pause. Playback only, paired with the thing
+ * you're watching. Timeline-view tools (timecode/fps readout, snap, follow,
+ * waveform style, zoom) live in the timeline toolbar, not here.
+ */
+export function TransportBar() {
+  const media = selectedMedia.value;
+  const playing = isPlaying.value;
+  if (!media) return null;
+
+  // One frame back/forward, paused — the same action as the Left/Right keys.
+  const stepFrame = (dir: 1 | -1) => {
+    const m = selectedMedia.peek();
+    const f = m?.fps ?? activeProfile.value.timing.defaultFps;
+    const dur = mediaDuration.peek() || (m?.captions.length ? m.captions[m.captions.length - 1].end : 0);
+    if (!f || !dur) return;
+    isPlaying.value = false; // stepping is a paused review action
+    const next = frameStep(playbackTime.peek(), f, dir);
+    playbackTime.value = Math.max(0, Math.min(dur, next));
+  };
+
+  const goToEnd = () => {
+    const m = selectedMedia.peek();
+    const dur = mediaDuration.peek() || (m?.captions.length ? m.captions[m.captions.length - 1].end : 0);
+    if (dur) playbackTime.value = dur;
+  };
+
+  return (
+    <div class="transport-bar">
+      <button class="timeline-btn" onClick={() => { playbackTime.value = 0; }} data-tooltip="Go to start">
+        <SkipBack size={14} weight="fill" />
+      </button>
+      <button class="timeline-btn" onClick={() => stepFrame(-1)} data-tooltip="Previous frame (←)">
+        <StepBack size={16} />
+      </button>
+      <button
+        class="timeline-btn timeline-btn--play"
+        onClick={() => { isPlaying.value = !isPlaying.peek(); }}
+        data-tooltip={playing ? "Pause (Space)" : "Play (Space)"}
+      >
+        {playing ? <Pause size={14} weight="fill" /> : <Play size={14} weight="fill" />}
+      </button>
+      <button class="timeline-btn" onClick={() => stepFrame(1)} data-tooltip="Next frame (→)">
+        <StepForward size={16} />
+      </button>
+      <button class="timeline-btn" onClick={goToEnd} data-tooltip="Go to end">
+        <SkipForward size={14} weight="fill" />
+      </button>
+    </div>
+  );
+}

--- a/src/components/layout/TransportBar.tsx
+++ b/src/components/layout/TransportBar.tsx
@@ -6,8 +6,7 @@ import {
   PlayIcon as Play,
   PauseIcon as Pause,
 } from "@phosphor-icons/react";
-import { selectedMedia, isPlaying, playbackTime, mediaDuration, activeProfile } from "../../store/app";
-import { frameStep } from "../../lib/playhead";
+import { selectedMedia, isPlaying, playbackTime, mediaDuration, stepPlayhead } from "../../store/app";
 
 /**
  * Playback transport — a strip docked under the video preview: go to start,
@@ -20,17 +19,6 @@ export function TransportBar() {
   const playing = isPlaying.value;
   if (!media) return null;
 
-  // One frame back/forward, paused — the same action as the Left/Right keys.
-  const stepFrame = (dir: 1 | -1) => {
-    const m = selectedMedia.peek();
-    const f = m?.fps ?? activeProfile.value.timing.defaultFps;
-    const dur = mediaDuration.peek() || (m?.captions.length ? m.captions[m.captions.length - 1].end : 0);
-    if (!f || !dur) return;
-    isPlaying.value = false; // stepping is a paused review action
-    const next = frameStep(playbackTime.peek(), f, dir);
-    playbackTime.value = Math.max(0, Math.min(dur, next));
-  };
-
   const goToEnd = () => {
     const m = selectedMedia.peek();
     const dur = mediaDuration.peek() || (m?.captions.length ? m.captions[m.captions.length - 1].end : 0);
@@ -42,7 +30,7 @@ export function TransportBar() {
       <button class="timeline-btn" onClick={() => { playbackTime.value = 0; }} data-tooltip="Go to start">
         <SkipBack size={14} weight="fill" />
       </button>
-      <button class="timeline-btn" onClick={() => stepFrame(-1)} data-tooltip="Previous frame (←)">
+      <button class="timeline-btn" onClick={() => stepPlayhead(-1)} data-tooltip="Previous frame (←)">
         <StepBack size={16} />
       </button>
       <button
@@ -52,7 +40,7 @@ export function TransportBar() {
       >
         {playing ? <Pause size={14} weight="fill" /> : <Play size={14} weight="fill" />}
       </button>
-      <button class="timeline-btn" onClick={() => stepFrame(1)} data-tooltip="Next frame (→)">
+      <button class="timeline-btn" onClick={() => stepPlayhead(1)} data-tooltip="Next frame (→)">
         <StepForward size={16} />
       </button>
       <button class="timeline-btn" onClick={goToEnd} data-tooltip="Go to end">

--- a/src/components/layout/VideoPanel.tsx
+++ b/src/components/layout/VideoPanel.tsx
@@ -6,6 +6,7 @@ import { editingIndex, editText } from "./CaptionPanel";
 import { AUDIO_EXTS } from "../../lib/project";
 import { findCaptionAt } from "../../lib/pipeline";
 import { getClipView } from "../../lib/clipView";
+import { frameMidpoint } from "../../lib/playhead";
 
 function isAudioOnly(path: string): boolean {
   const ext = path.replace(/\\/g, "/").split(".").pop()?.toLowerCase() ?? "";
@@ -115,8 +116,12 @@ export function VideoPanel() {
     const video = videoRef.current;
     if (!video) return;
     if (rafActiveRef.current) return;
-    if (Math.abs(video.currentTime - currentTime) > 1 / (2 * fps)) {
-      video.currentTime = currentTime;
+    // Seek to the middle of the frame containing currentTime (see frameMidpoint):
+    // a frame-boundary seek is ambiguous and makes stepping land a frame early/late
+    // at random. The playhead stays on the boundary; only the video seek is nudged.
+    const target = frameMidpoint(currentTime, fps);
+    if (Math.abs(video.currentTime - target) > 1 / (2 * fps)) {
+      video.currentTime = target;
     }
   }, [currentTime, fps, playing]);
 

--- a/src/lib/__tests__/playhead.test.ts
+++ b/src/lib/__tests__/playhead.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { frameStep, frameMidpoint, nextBoundary, clampStart, clampEnd } from "../playhead";
+import { frameStep, frameMidpoint, nextBoundary, clampStart, clampEnd, computeTrim } from "../playhead";
 
 const FPS = 30;
 
@@ -90,5 +90,37 @@ describe("clampEnd", () => {
   });
   it("caps at the clip duration when there is no next caption", () => {
     expect(clampEnd(99, 1, null, 10, 0.1)).toBe(10);
+  });
+});
+
+describe("computeTrim", () => {
+  // Captions 1 & 2 share a boundary at 3.0s; a gap precedes caption 3.
+  const caps = [
+    { index: 1, start: 1, end: 3 },
+    { index: 2, start: 3, end: 5 },
+    { index: 3, start: 6, end: 8 },
+  ];
+  const FPS = 30, DUR = 10;
+
+  it("trims the in point to the playhead", () => {
+    expect(computeTrim(caps, 2, "in", 4, FPS, DUR)).toEqual({ start: 4, end: 5 });
+  });
+  it("trims the out point to the playhead", () => {
+    expect(computeTrim(caps, 1, "out", 2, FPS, DUR)).toEqual({ start: 1, end: 2 });
+  });
+  it("clamps the in point to the previous caption's end → no-op at a shared boundary", () => {
+    expect(computeTrim(caps, 2, "in", 2, FPS, DUR)).toBeNull();
+  });
+  it("clamps the out point to the next caption's start → no-op at a shared boundary", () => {
+    expect(computeTrim(caps, 1, "out", 4, FPS, DUR)).toBeNull();
+  });
+  it("first caption's in can reach the clip start (no previous caption)", () => {
+    expect(computeTrim(caps, 1, "in", 0.5, FPS, DUR)).toEqual({ start: 0.5, end: 3 });
+  });
+  it("last caption's out can reach the clip duration (no next caption)", () => {
+    expect(computeTrim(caps, 3, "out", 9, FPS, DUR)).toEqual({ start: 6, end: 9 });
+  });
+  it("returns null when the caption isn't found", () => {
+    expect(computeTrim(caps, 99, "in", 4, FPS, DUR)).toBeNull();
   });
 });

--- a/src/lib/__tests__/playhead.test.ts
+++ b/src/lib/__tests__/playhead.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { frameStep, frameMidpoint, nextBoundary, clampStart, clampEnd, computeTrim } from "../playhead";
+import { frameStep, frameMidpoint, nextBoundary, clampStart, clampEnd, computeTrim, computeRoll } from "../playhead";
 
 const FPS = 30;
 
@@ -122,5 +122,44 @@ describe("computeTrim", () => {
   });
   it("returns null when the caption isn't found", () => {
     expect(computeTrim(caps, 99, "in", 4, FPS, DUR)).toBeNull();
+  });
+});
+
+describe("computeRoll", () => {
+  // Captions 1 & 2 share a cut at 3.0s; a gap precedes caption 3.
+  const caps = [
+    { index: 1, start: 1, end: 3 },
+    { index: 2, start: 3, end: 5 },
+    { index: 3, start: 6, end: 8 },
+  ];
+
+  it("rolls the shared cut on the selected caption's in side (both edges move)", () => {
+    expect(computeRoll(caps, 2, "in", 3.5, FPS)).toEqual({
+      left: { index: 1, start: 1, end: 3.5 },
+      right: { index: 2, start: 3.5, end: 5 },
+    });
+  });
+  it("rolls the same cut from the neighbour's out side", () => {
+    expect(computeRoll(caps, 1, "out", 3.5, FPS)).toEqual({
+      left: { index: 1, start: 1, end: 3.5 },
+      right: { index: 2, start: 3.5, end: 5 },
+    });
+  });
+  it("clamps the cut so neither caption drops below a frame", () => {
+    const r = computeRoll(caps, 2, "in", 0, FPS); // dragged far past the left
+    expect(r?.left.end).toBeCloseTo(1 + 1 / FPS, 9);
+    expect(r?.right.start).toBeCloseTo(1 + 1 / FPS, 9);
+  });
+  it("is a no-op when the cut wouldn't move", () => {
+    expect(computeRoll(caps, 2, "in", 3, FPS)).toBeNull();
+  });
+  it("returns null with no neighbour on that side (first caption's in)", () => {
+    expect(computeRoll(caps, 1, "in", 2, FPS)).toBeNull();
+  });
+  it("returns null with no neighbour on that side (last caption's out)", () => {
+    expect(computeRoll(caps, 3, "out", 7, FPS)).toBeNull();
+  });
+  it("returns null when the boundary isn't shared (a gap, not a cut)", () => {
+    expect(computeRoll(caps, 2, "out", 5.5, FPS)).toBeNull();
   });
 });

--- a/src/lib/__tests__/playhead.test.ts
+++ b/src/lib/__tests__/playhead.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { frameStep, frameMidpoint, nextBoundary } from "../playhead";
+
+const FPS = 30;
+
+describe("frameStep", () => {
+  it("on a frame: advances exactly one in each direction", () => {
+    expect(frameStep(5 / FPS, FPS, 1)).toBeCloseTo(6 / FPS, 9);
+    expect(frameStep(5 / FPS, FPS, -1)).toBeCloseTo(4 / FPS, 9);
+  });
+
+  it("between frames: snaps to the boundary in the press direction, not the nearest frame", () => {
+    // Playhead in the FAR half between frames 1 and 2 (closer to 2). Right must
+    // still land on 2 — the regression: "round to nearest, then +1" jumps to 3.
+    expect(frameStep(1.7 / FPS, FPS, 1)).toBeCloseTo(2 / FPS, 9);
+    // Near half (closer to 1): Right also lands on 2.
+    expect(frameStep(1.3 / FPS, FPS, 1)).toBeCloseTo(2 / FPS, 9);
+    // Left from anywhere between 1 and 2 lands on 1.
+    expect(frameStep(1.7 / FPS, FPS, -1)).toBeCloseTo(1 / FPS, 9);
+    expect(frameStep(1.3 / FPS, FPS, -1)).toBeCloseTo(1 / FPS, 9);
+  });
+
+  it("frame 0 (caller clamps the negative result to the clip start)", () => {
+    expect(frameStep(0, FPS, 1)).toBeCloseTo(1 / FPS, 9);
+    expect(frameStep(0, FPS, -1)).toBeCloseTo(-1 / FPS, 9);
+  });
+});
+
+describe("frameMidpoint", () => {
+  it("targets the middle of the frame containing the time", () => {
+    expect(frameMidpoint(5 / FPS, FPS)).toBeCloseTo(5.5 / FPS, 9);   // on a boundary → mid of frame 5
+    expect(frameMidpoint(5.2 / FPS, FPS)).toBeCloseTo(5.5 / FPS, 9); // within frame 5
+    expect(frameMidpoint(5.9 / FPS, FPS)).toBeCloseTo(5.5 / FPS, 9); // still frame 5
+  });
+});
+
+describe("nextBoundary", () => {
+  const bounds = [0, 1, 2.5, 4];
+
+  it("forward: first boundary after the time", () => {
+    expect(nextBoundary(0.5, bounds, 1)).toBe(1);
+    expect(nextBoundary(1.5, bounds, 1)).toBe(2.5);
+  });
+
+  it("backward: last boundary before the time", () => {
+    expect(nextBoundary(1.5, bounds, -1)).toBe(1);
+    expect(nextBoundary(0.5, bounds, -1)).toBe(0);
+  });
+
+  it("skips a boundary the playhead is sitting on (so repeated presses advance)", () => {
+    expect(nextBoundary(1, bounds, 1)).toBe(2.5);
+    expect(nextBoundary(2.5, bounds, -1)).toBe(1);
+  });
+
+  it("undefined past the ends", () => {
+    expect(nextBoundary(4, bounds, 1)).toBeUndefined();
+    expect(nextBoundary(0, bounds, -1)).toBeUndefined();
+  });
+
+  it("sorts unsorted input", () => {
+    expect(nextBoundary(1.5, [4, 0, 2.5, 1], 1)).toBe(2.5);
+  });
+});

--- a/src/lib/__tests__/playhead.test.ts
+++ b/src/lib/__tests__/playhead.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { frameStep, frameMidpoint, nextBoundary } from "../playhead";
+import { frameStep, frameMidpoint, nextBoundary, clampStart, clampEnd } from "../playhead";
 
 const FPS = 30;
 
@@ -59,5 +59,36 @@ describe("nextBoundary", () => {
 
   it("sorts unsorted input", () => {
     expect(nextBoundary(1.5, [4, 0, 2.5, 1], 1)).toBe(2.5);
+  });
+});
+
+describe("clampStart", () => {
+  it("passes a value already inside the valid range", () => {
+    expect(clampStart(2, 1, 5, 0.1)).toBe(2);
+  });
+  it("clamps to the previous caption's end (no overlap)", () => {
+    expect(clampStart(0.5, 1, 5, 0.1)).toBe(1);
+  });
+  it("clamps to own end minus the minimum duration (no invert/collapse)", () => {
+    expect(clampStart(4.99, 1, 5, 0.1)).toBeCloseTo(4.9, 9);
+  });
+  it("floors at 0 when there is no previous caption", () => {
+    expect(clampStart(-1, null, 5, 0.1)).toBe(0);
+    expect(clampStart(0.5, null, 5, 0.1)).toBe(0.5);
+  });
+});
+
+describe("clampEnd", () => {
+  it("passes a value already inside the valid range", () => {
+    expect(clampEnd(3, 1, 5, 10, 0.1)).toBe(3);
+  });
+  it("clamps to the next caption's start (no overlap)", () => {
+    expect(clampEnd(5.5, 1, 5, 10, 0.1)).toBe(5);
+  });
+  it("clamps to own start plus the minimum duration (no invert/collapse)", () => {
+    expect(clampEnd(1.01, 1, 5, 10, 0.1)).toBeCloseTo(1.1, 9);
+  });
+  it("caps at the clip duration when there is no next caption", () => {
+    expect(clampEnd(99, 1, null, 10, 0.1)).toBe(10);
   });
 });

--- a/src/lib/__tests__/waveform.test.ts
+++ b/src/lib/__tests__/waveform.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { computePeakMax, continuousBinRange, reduceColumns } from "../waveform";
+
+describe("computePeakMax", () => {
+  it("returns the largest peak", () => {
+    expect(computePeakMax(new Float32Array([0.1, 0.5, 0.3]))).toBe(0.5);
+  });
+  it("is 0 for empty or all-zero input", () => {
+    expect(computePeakMax(new Float32Array([]))).toBe(0);
+    expect(computePeakMax(new Float32Array([0, 0, 0]))).toBe(0);
+  });
+});
+
+describe("continuousBinRange", () => {
+  // pxPerSec=100, binsPerSec=10 → one bin per 10 content px; binCount=1000.
+  const P = 100, B = 10, N = 1000;
+  it("clamps the start to 0 (with the leading -1 pad)", () => {
+    expect(continuousBinRange(0, 200, P, B, N)).toEqual({ firstBin: 0, lastBin: 21 });
+  });
+  it("windows to the visible span, padded one column each side", () => {
+    expect(continuousBinRange(500, 200, P, B, N)).toEqual({ firstBin: 49, lastBin: 71 });
+  });
+  it("clamps the end to the last bin", () => {
+    expect(continuousBinRange(9900, 200, P, B, N)).toEqual({ firstBin: 989, lastBin: 999 });
+  });
+});
+
+describe("reduceColumns", () => {
+  // Exact binary-fraction peaks + ampScale so the float math is exact for toEqual.
+  const x: number[] = [];
+  const a: number[] = [];
+
+  it("emits one max-reduced point per content column", () => {
+    // binsPerSec=1, pxPerSec=1 → col = bin; ampScale=4, minAmp=0.1.
+    reduceColumns([0.5, 0.25, 0.75], 0, 2, 1, 1, 4, 0.1, x, a);
+    expect(x).toEqual([0, 1, 2]);
+    expect(a).toEqual([2, 1, 3]); // 0.5×4, 0.25×4, 0.75×4
+  });
+
+  it("max-reduces multiple bins that fall in one column", () => {
+    // pxPerSec=0.5 → col = floor(bin/2): bins 0,1 → col 0; bins 2,3 → col 1.
+    reduceColumns([0.25, 0.75, 0.5, 0.125], 0, 3, 1, 0.5, 4, 0.1, x, a);
+    expect(x).toEqual([0, 1]);
+    expect(a).toEqual([3, 2]); // col0 max 0.75→3, col1 max 0.5→2
+  });
+
+  it("floors silent/quiet columns at minAmp so they read as a thin line", () => {
+    reduceColumns([0, 0.0625], 0, 1, 1, 1, 4, 1, x, a);
+    expect(x).toEqual([0, 1]);
+    expect(a).toEqual([1, 1]); // 0→floored to 1; 0.0625×4=0.25→floored to 1
+  });
+
+  it("clears the output buffers first (they're reused across paints)", () => {
+    x.push(999); a.push(999);
+    reduceColumns([0.5], 0, 0, 1, 1, 4, 0.1, x, a);
+    expect(x).toEqual([0]);
+    expect(a).toEqual([2]);
+  });
+
+  it("emits nothing for an empty bin range", () => {
+    reduceColumns([0.5, 0.6], 1, 0, 1, 1, 4, 0.1, x, a); // firstBin > lastBin
+    expect(x).toEqual([]);
+    expect(a).toEqual([]);
+  });
+});

--- a/src/lib/playhead.ts
+++ b/src/lib/playhead.ts
@@ -3,6 +3,7 @@
  * Timeline and VideoPanel components so the boundary math — which is fiddly and
  * has had off-by-one bugs — can be unit-tested in isolation.
  */
+import { snapToFrame } from "./pipeline";
 
 // Absorbs floating-point error in `time * fps` for frame-aligned times (e.g. a
 // playhead parked at frame N via N/fps, whose round-trip lands at N ± ~1e-12).
@@ -69,4 +70,37 @@ export function clampStart(time: number, prevEnd: number | null, ownEnd: number,
  *  past the next caption's start (or the clip duration). */
 export function clampEnd(time: number, ownStart: number, nextStart: number | null, dur: number, minDur: number): number {
   return Math.max(ownStart + minDur, Math.min(time, nextStart ?? dur));
+}
+
+export interface TrimResult { start: number; end: number; }
+
+/**
+ * New timing for trimming the caption at `index`'s in/out edge to `time` (the
+ * playhead). Picks the neighbouring caption's edge as the bound, clamps so it
+ * can't overlap the neighbour or collapse below one frame, and snaps to a frame.
+ * Returns null when the caption isn't found or the edge wouldn't move — a no-op
+ * the caller should skip rather than commit to undo history. `captions` are
+ * assumed sorted by start (the editor's invariant), so the array neighbours are
+ * the temporal ones.
+ */
+export function computeTrim(
+  captions: readonly { index: number; start: number; end: number }[],
+  index: number,
+  edge: "in" | "out",
+  time: number,
+  fps: number,
+  dur: number,
+): TrimResult | null {
+  const pos = captions.findIndex((c) => c.index === index);
+  if (pos < 0) return null;
+  const cap = captions[pos];
+  const minDur = 1 / fps;
+  if (edge === "in") {
+    const prevEnd = pos > 0 ? captions[pos - 1].end : null;
+    const start = snapToFrame(clampStart(time, prevEnd, cap.end, minDur), fps);
+    return start === cap.start ? null : { start, end: cap.end };
+  }
+  const nextStart = pos < captions.length - 1 ? captions[pos + 1].start : null;
+  const end = snapToFrame(clampEnd(time, cap.start, nextStart, dur, minDur), fps);
+  return end === cap.end ? null : { start: cap.start, end };
 }

--- a/src/lib/playhead.ts
+++ b/src/lib/playhead.ts
@@ -52,3 +52,21 @@ export function nextBoundary(
   }
   return undefined;
 }
+
+// ── Caption edge clamps (shared by the resize-handle drag and [ / ] trim) ─────
+// Both clamp a proposed edge time to its valid range so it can't overlap the
+// neighbouring caption or collapse the caption below `minDur`. `prevEnd`/`nextStart`
+// are the adjacent captions' edges (null at the clip ends → 0 / clip duration).
+// Callers snap the result to a frame.
+
+/** Clamp a caption's start edge: not before the previous caption's end, and at
+ *  least `minDur` before its own end. */
+export function clampStart(time: number, prevEnd: number | null, ownEnd: number, minDur: number): number {
+  return Math.max(prevEnd ?? 0, Math.min(time, ownEnd - minDur));
+}
+
+/** Clamp a caption's end edge: at least `minDur` after its own start, and not
+ *  past the next caption's start (or the clip duration). */
+export function clampEnd(time: number, ownStart: number, nextStart: number | null, dur: number, minDur: number): number {
+  return Math.max(ownStart + minDur, Math.min(time, nextStart ?? dur));
+}

--- a/src/lib/playhead.ts
+++ b/src/lib/playhead.ts
@@ -104,3 +104,41 @@ export function computeTrim(
   const end = snapToFrame(clampEnd(time, cap.start, nextStart, dur, minDur), fps);
   return end === cap.end ? null : { start: cap.start, end };
 }
+
+export interface RollResult {
+  left: { index: number; start: number; end: number };
+  right: { index: number; start: number; end: number };
+}
+
+/**
+ * Compute a rolling edit: move the shared cut on the selected caption's `side`
+ * (the boundary it shares with its previous/next neighbour) to `time`, dragging
+ * both flanking edges with it — left.end and right.start both become the cut. The
+ * cut is clamped within the two captions (each keeps ≥ one frame) and snapped to a
+ * frame. Returns null if there's no neighbour on that side, the boundary isn't
+ * shared (a gap — nothing to roll), the caption isn't found, or it'd be a no-op.
+ * `captions` are assumed sorted by start, so array neighbours are temporal ones.
+ */
+export function computeRoll(
+  captions: readonly { index: number; start: number; end: number }[],
+  index: number,
+  side: "in" | "out",
+  time: number,
+  fps: number,
+  eps = 1e-4,
+): RollResult | null {
+  const pos = captions.findIndex((c) => c.index === index);
+  if (pos < 0) return null;
+  // The two captions flanking the cut: left | right.
+  const left = captions[side === "in" ? pos - 1 : pos];
+  const right = captions[side === "in" ? pos : pos + 1];
+  if (!left || !right) return null; // no neighbour on that side
+  if (Math.abs(left.end - right.start) > eps) return null; // not a shared boundary
+  const minDur = 1 / fps;
+  const cut = snapToFrame(Math.max(left.start + minDur, Math.min(time, right.end - minDur)), fps);
+  if (cut === left.end) return null; // cut wouldn't move
+  return {
+    left: { index: left.index, start: left.start, end: cut },
+    right: { index: right.index, start: cut, end: right.end },
+  };
+}

--- a/src/lib/playhead.ts
+++ b/src/lib/playhead.ts
@@ -1,0 +1,54 @@
+/**
+ * Pure playhead / frame arithmetic for timeline navigation. Extracted from the
+ * Timeline and VideoPanel components so the boundary math — which is fiddly and
+ * has had off-by-one bugs — can be unit-tested in isolation.
+ */
+
+// Absorbs floating-point error in `time * fps` for frame-aligned times (e.g. a
+// playhead parked at frame N via N/fps, whose round-trip lands at N ± ~1e-12).
+const FRAME_EPS = 1e-6;
+
+/**
+ * Time of the adjacent frame BOUNDARY from `time` in direction `dir`
+ * (1 = forward, -1 = back). Always moves to the next/previous frame boundary,
+ * regardless of where within the current frame the playhead sits — NOT "round to
+ * the nearest frame, then ±1", which skips a frame when the playhead is in the
+ * far half between two frames. A playhead already on a frame advances by exactly
+ * one. Not clamped to the clip — the caller does that.
+ */
+export function frameStep(time: number, fps: number, dir: 1 | -1): number {
+  const frame = dir > 0
+    ? Math.floor(time * fps + FRAME_EPS) + 1
+    : Math.ceil(time * fps - FRAME_EPS) - 1;
+  return frame / fps;
+}
+
+/**
+ * Time to seek a <video> element to so it reliably displays the frame containing
+ * `time`: the middle of that frame. Seeking to a frame boundary (N/fps) is
+ * ambiguous — it sits on the seam between frames N-1 and N, so the decoder may
+ * resolve to either, making frame-stepping land a frame early/late at random.
+ */
+export function frameMidpoint(time: number, fps: number): number {
+  return (Math.floor(time * fps + FRAME_EPS) + 0.5) / fps;
+}
+
+/**
+ * Nearest value in `bounds` strictly past `time` in direction `dir` (1 = next,
+ * -1 = previous), or undefined if there is none. `bounds` need not be sorted.
+ * `eps` makes a boundary the playhead is essentially sitting on get skipped, so
+ * repeated presses advance instead of sticking.
+ */
+export function nextBoundary(
+  time: number,
+  bounds: number[],
+  dir: 1 | -1,
+  eps = 1e-4,
+): number | undefined {
+  const sorted = [...bounds].sort((a, b) => a - b);
+  if (dir > 0) return sorted.find((b) => b > time + eps);
+  for (let i = sorted.length - 1; i >= 0; i--) {
+    if (sorted[i] < time - eps) return sorted[i];
+  }
+  return undefined;
+}

--- a/src/lib/waveform.ts
+++ b/src/lib/waveform.ts
@@ -5,8 +5,8 @@
  * waveform up front (O(zoom × duration) canvas pixels, all rebuilt on
  * every zoom step). The canvas here is viewport-sized and position:sticky
  * at the left edge of the scroll viewport; each repaint draws only the
- * visible bars, so per-frame cost is O(viewport) regardless of zoom level
- * or media length.
+ * visible portion of the waveform, so per-frame cost is O(viewport)
+ * regardless of zoom level or media length.
  *
  * Repaints are coalesced to one per animation frame and triggered by
  * scroll, by row resize (which covers both window resizes and zoom — the
@@ -20,10 +20,14 @@
  * pipeline resolved.
  */
 
-// Bar styling matches the previous WaveSurfer config (CSS px).
+/** How the waveform is drawn: discrete bars, or a continuous filled envelope. */
+export type WaveformStyle = "bars" | "continuous";
+
+// Bar styling for the "bars" style (CSS px).
 const BAR_WIDTH = 2;
 const BAR_GAP = 1;
 const BAR_RADIUS = 2;
+// Fill for the waveform.
 const WAVE_COLOR = "#374151";
 
 export interface WaveformPainter {
@@ -34,6 +38,8 @@ export interface WaveformPainter {
    *  before the video does just leaves the tail of the row empty — only bins
    *  that exist are drawn. */
   setLayoutDuration(seconds: number): void;
+  /** Switch between the bars and continuous-envelope renderings. */
+  setStyle(style: WaveformStyle): void;
   schedulePaint(): void;
   destroy(): void;
 }
@@ -53,6 +59,11 @@ export function createWaveformPainter(opts: {
   let layoutDuration = 0;
   let peakMax = 0;
   let raf = 0;
+  let style: WaveformStyle = "continuous";
+  // Reused across paints (this runs on the per-scroll-frame hot path) to avoid
+  // per-frame allocation: the envelope's content-x and half-amplitude per column.
+  const pxBuf: number[] = [];
+  const ampBuf: number[] = [];
 
   const paint = () => {
     if (!ctx) return;
@@ -75,47 +86,74 @@ export function createWaveformPainter(opts: {
 
     if (!peaks || !peaks.length || peakMax <= 0 || audioDuration <= 0 || layoutDuration <= 0) return;
 
-    // All geometry below is in device px.
+    // Geometry shared by both styles (all in device px). Normalize amplitude
+    // against the global max so it reads the same at every zoom level.
     const totalWidth = scrollEl.scrollWidth * dpr;
     const scrollLeft = scrollEl.scrollLeft * dpr;
     const pxPerSec = totalWidth / layoutDuration;
     const binsPerSec = peaks.length / audioDuration;
-    const spacing = (BAR_WIDTH + BAR_GAP) * dpr;
-    const barWidth = BAR_WIDTH * dpr;
-    const radius = BAR_RADIUS * dpr;
     const halfHeight = h / 2;
-    // Normalize against the global max so amplitude reads the same at
-    // every zoom level (WaveSurfer normalized per 8000px chunk).
-    const vScale = 1 / peakMax;
-
-    // Visible bin range, padded one column left so a partially visible
-    // edge bar still draws.
-    const firstBin = Math.max(0, Math.floor(((scrollLeft - spacing) / pxPerSec) * binsPerSec));
-    const lastBin = Math.min(peaks.length - 1, Math.ceil(((scrollLeft + w) / pxPerSec) * binsPerSec));
-
-    // One bar per grid column, max-reduced over the bins that start in it.
-    // The grid is anchored to the content (not the viewport) so bars stay
-    // put while panning. Zoomed past the data density (under one bin per
-    // column) this leaves empty columns rather than inventing detail.
+    const ampScale = halfHeight / peakMax;
     ctx.fillStyle = WAVE_COLOR;
-    ctx.beginPath();
-    let column = -1;
-    let columnMax = 0;
-    const flush = () => {
-      if (column < 0) return;
-      const top = Math.round(columnMax * halfHeight * vScale);
-      ctx.roundRect(column * spacing - scrollLeft, halfHeight - top, barWidth, top * 2 || 1, radius);
-    };
-    for (let b = firstBin; b <= lastBin; b++) {
-      const col = Math.floor(((b / binsPerSec) * pxPerSec) / spacing);
-      if (col !== column) {
-        flush();
-        column = col;
-        columnMax = 0;
+
+    if (style === "bars") {
+      // One rounded bar per grid column, max-reduced over the bins in it. The
+      // grid is anchored to the content (not the viewport) so bars stay put
+      // while panning. Zoomed past the data density (under one bin per column)
+      // this leaves empty columns rather than inventing detail.
+      const spacing = (BAR_WIDTH + BAR_GAP) * dpr;
+      const barWidth = BAR_WIDTH * dpr;
+      const radius = BAR_RADIUS * dpr;
+      const firstBin = Math.max(0, Math.floor(((scrollLeft - spacing) / pxPerSec) * binsPerSec));
+      const lastBin = Math.min(peaks.length - 1, Math.ceil(((scrollLeft + w) / pxPerSec) * binsPerSec));
+      ctx.beginPath();
+      let column = -1;
+      let columnMax = 0;
+      const flush = () => {
+        if (column < 0) return;
+        const top = Math.round(columnMax * ampScale);
+        ctx.roundRect(column * spacing - scrollLeft, halfHeight - top, barWidth, top * 2 || 1, radius);
+      };
+      for (let b = firstBin; b <= lastBin; b++) {
+        const col = Math.floor(((b / binsPerSec) * pxPerSec) / spacing);
+        if (col !== column) { flush(); column = col; columnMax = 0; }
+        if (peaks[b] > columnMax) columnMax = peaks[b];
       }
-      if (peaks[b] > columnMax) columnMax = peaks[b];
+      flush();
+      ctx.fill();
+      return;
     }
-    flush();
+
+    // Continuous: max-reduce bins into integer content-pixel columns — one
+    // envelope point per column. Bins are in position order, so columns come out
+    // ordered and a point is emitted each time the column advances. The points
+    // are connected into one filled shape mirrored about the centerline — a
+    // continuous waveform. Zoomed past the data density the points spread out and
+    // the fill interpolates between them (a smooth envelope) rather than leaving
+    // gaps. Floor each column so silence still reads as a thin centerline.
+    const minAmp = 0.5 * dpr;
+    const firstBin = Math.max(0, Math.floor((scrollLeft / pxPerSec) * binsPerSec) - 1);
+    const lastBin = Math.min(peaks.length - 1, Math.ceil(((scrollLeft + w) / pxPerSec) * binsPerSec) + 1);
+    pxBuf.length = 0;
+    ampBuf.length = 0;
+    let curCol = -1;
+    let curMax = 0;
+    for (let b = firstBin; b <= lastBin; b++) {
+      const col = Math.floor((b / binsPerSec) * pxPerSec);
+      if (col !== curCol) {
+        if (curCol >= 0) { pxBuf.push(curCol); ampBuf.push(Math.max(curMax * ampScale, minAmp)); }
+        curCol = col;
+        curMax = 0;
+      }
+      if (peaks[b] > curMax) curMax = peaks[b];
+    }
+    if (curCol >= 0) { pxBuf.push(curCol); ampBuf.push(Math.max(curMax * ampScale, minAmp)); }
+    if (!pxBuf.length) return;
+    ctx.beginPath();
+    ctx.moveTo(pxBuf[0] - scrollLeft, halfHeight - ampBuf[0]);
+    for (let i = 1; i < pxBuf.length; i++) ctx.lineTo(pxBuf[i] - scrollLeft, halfHeight - ampBuf[i]);
+    for (let i = pxBuf.length - 1; i >= 0; i--) ctx.lineTo(pxBuf[i] - scrollLeft, halfHeight + ampBuf[i]);
+    ctx.closePath();
     ctx.fill();
   };
 
@@ -150,6 +188,11 @@ export function createWaveformPainter(opts: {
     setLayoutDuration(seconds) {
       if (seconds === layoutDuration) return;
       layoutDuration = seconds;
+      schedulePaint();
+    },
+    setStyle(s) {
+      if (s === style) return;
+      style = s;
       schedulePaint();
     },
     schedulePaint,

--- a/src/lib/waveform.ts
+++ b/src/lib/waveform.ts
@@ -30,6 +30,64 @@ const BAR_RADIUS = 2;
 // Fallback fill if the --tl-waveform CSS variable can't be read.
 const DEFAULT_WAVE_COLOR = "#374151";
 
+// ── Pure reduction helpers ────────────────────────────────────────────────────
+// Lifted out of the painter so the fiddly bin→column math (where off-by-ones and
+// scale bugs hide) is unit-testable without a canvas. The painter calls these.
+
+/** Largest peak in the envelope — the global normalization reference. */
+export function computePeakMax(peaks: Float32Array | number[]): number {
+  let max = 0;
+  for (let i = 0; i < peaks.length; i++) if (peaks[i] > max) max = peaks[i];
+  return max;
+}
+
+/** Bins whose content-pixel columns intersect the viewport
+ *  [scrollLeftPx, scrollLeftPx + viewWidthPx], padded one column each side so the
+ *  filled envelope reaches both edges, clamped to [0, binCount - 1]. Device px. */
+export function continuousBinRange(
+  scrollLeftPx: number,
+  viewWidthPx: number,
+  pxPerSec: number,
+  binsPerSec: number,
+  binCount: number,
+): { firstBin: number; lastBin: number } {
+  const firstBin = Math.max(0, Math.floor((scrollLeftPx / pxPerSec) * binsPerSec) - 1);
+  const lastBin = Math.min(binCount - 1, Math.ceil(((scrollLeftPx + viewWidthPx) / pxPerSec) * binsPerSec) + 1);
+  return { firstBin, lastBin };
+}
+
+/** Max-reduce peak bins [firstBin, lastBin] into integer content-pixel columns:
+ *  one envelope point per column, its amplitude the per-column max × ampScale
+ *  floored at minAmp (so silence still reads as a thin centerline).
+ *  col = floor((bin / binsPerSec) × pxPerSec). Writes into outX/outAmp (cleared
+ *  first; passed in so the painter reuses buffers and avoids per-frame allocation). */
+export function reduceColumns(
+  peaks: Float32Array | number[],
+  firstBin: number,
+  lastBin: number,
+  binsPerSec: number,
+  pxPerSec: number,
+  ampScale: number,
+  minAmp: number,
+  outX: number[],
+  outAmp: number[],
+): void {
+  outX.length = 0;
+  outAmp.length = 0;
+  let curCol = -1;
+  let curMax = 0;
+  for (let b = firstBin; b <= lastBin; b++) {
+    const col = Math.floor((b / binsPerSec) * pxPerSec);
+    if (col !== curCol) {
+      if (curCol >= 0) { outX.push(curCol); outAmp.push(Math.max(curMax * ampScale, minAmp)); }
+      curCol = col;
+      curMax = 0;
+    }
+    if (peaks[b] > curMax) curMax = peaks[b];
+  }
+  if (curCol >= 0) { outX.push(curCol); outAmp.push(Math.max(curMax * ampScale, minAmp)); }
+}
+
 export interface WaveformPainter {
   /** Peak envelope from the pipeline. audioDuration is the seconds the peaks
    *  cover (sidecar-reported). */
@@ -135,22 +193,8 @@ export function createWaveformPainter(opts: {
     // the fill interpolates between them (a smooth envelope) rather than leaving
     // gaps. Floor each column so silence still reads as a thin centerline.
     const minAmp = 0.5 * dpr;
-    const firstBin = Math.max(0, Math.floor((scrollLeft / pxPerSec) * binsPerSec) - 1);
-    const lastBin = Math.min(peaks.length - 1, Math.ceil(((scrollLeft + w) / pxPerSec) * binsPerSec) + 1);
-    pxBuf.length = 0;
-    ampBuf.length = 0;
-    let curCol = -1;
-    let curMax = 0;
-    for (let b = firstBin; b <= lastBin; b++) {
-      const col = Math.floor((b / binsPerSec) * pxPerSec);
-      if (col !== curCol) {
-        if (curCol >= 0) { pxBuf.push(curCol); ampBuf.push(Math.max(curMax * ampScale, minAmp)); }
-        curCol = col;
-        curMax = 0;
-      }
-      if (peaks[b] > curMax) curMax = peaks[b];
-    }
-    if (curCol >= 0) { pxBuf.push(curCol); ampBuf.push(Math.max(curMax * ampScale, minAmp)); }
+    const { firstBin, lastBin } = continuousBinRange(scrollLeft, w, pxPerSec, binsPerSec, peaks.length);
+    reduceColumns(peaks, firstBin, lastBin, binsPerSec, pxPerSec, ampScale, minAmp, pxBuf, ampBuf);
     if (!pxBuf.length) return;
     ctx.beginPath();
     ctx.moveTo(pxBuf[0] - scrollLeft, halfHeight - ampBuf[0]);
@@ -182,10 +226,7 @@ export function createWaveformPainter(opts: {
     setPeaks(p, dur) {
       peaks = p;
       audioDuration = dur;
-      peakMax = 0;
-      for (let i = 0; i < p.length; i++) {
-        if (p[i] > peakMax) peakMax = p[i];
-      }
+      peakMax = computePeakMax(p);
       schedulePaint();
     },
     setLayoutDuration(seconds) {

--- a/src/lib/waveform.ts
+++ b/src/lib/waveform.ts
@@ -27,8 +27,8 @@ export type WaveformStyle = "bars" | "continuous";
 const BAR_WIDTH = 2;
 const BAR_GAP = 1;
 const BAR_RADIUS = 2;
-// Fill for the waveform.
-const WAVE_COLOR = "#374151";
+// Fallback fill if the --tl-waveform CSS variable can't be read.
+const DEFAULT_WAVE_COLOR = "#374151";
 
 export interface WaveformPainter {
   /** Peak envelope from the pipeline. audioDuration is the seconds the peaks
@@ -40,6 +40,8 @@ export interface WaveformPainter {
   setLayoutDuration(seconds: number): void;
   /** Switch between the bars and continuous-envelope renderings. */
   setStyle(style: WaveformStyle): void;
+  /** Set the fill color (sourced from the --tl-waveform CSS variable). */
+  setColor(color: string): void;
   schedulePaint(): void;
   destroy(): void;
 }
@@ -60,6 +62,7 @@ export function createWaveformPainter(opts: {
   let peakMax = 0;
   let raf = 0;
   let style: WaveformStyle = "continuous";
+  let color = DEFAULT_WAVE_COLOR;
   // Reused across paints (this runs on the per-scroll-frame hot path) to avoid
   // per-frame allocation: the envelope's content-x and half-amplitude per column.
   const pxBuf: number[] = [];
@@ -94,7 +97,7 @@ export function createWaveformPainter(opts: {
     const binsPerSec = peaks.length / audioDuration;
     const halfHeight = h / 2;
     const ampScale = halfHeight / peakMax;
-    ctx.fillStyle = WAVE_COLOR;
+    ctx.fillStyle = color;
 
     if (style === "bars") {
       // One rounded bar per grid column, max-reduced over the bins in it. The
@@ -193,6 +196,11 @@ export function createWaveformPainter(opts: {
     setStyle(s) {
       if (s === style) return;
       style = s;
+      schedulePaint();
+    },
+    setColor(c) {
+      if (!c || c === color) return;
+      color = c;
       schedulePaint();
     },
     schedulePaint,

--- a/src/store/__tests__/app.test.ts
+++ b/src/store/__tests__/app.test.ts
@@ -559,4 +559,14 @@ describe("followPlayhead (auto-select caption under playhead)", () => {
     playbackTime.value = 2.5; // inside caption 2, but follow is off
     expect(selectedCaptionIndex.value).toBeNull();
   });
+
+  it("re-selects after a manual deselect when the playhead moves within the same caption", () => {
+    followPlayhead.value = true;
+    playbackTime.value = 0.5; // inside caption 1
+    expect(selectedCaptionIndex.value).toBe(1);
+    selectedCaptionIndex.value = null; // click off to deselect; playhead still over caption 1
+    expect(selectedCaptionIndex.value).toBeNull(); // stays deselected with no playhead move
+    playbackTime.value = 0.6; // frame-step within caption 1 — no boundary crossing
+    expect(selectedCaptionIndex.value).toBe(1); // re-asserted on the move
+  });
 });

--- a/src/store/__tests__/app.test.ts
+++ b/src/store/__tests__/app.test.ts
@@ -9,6 +9,8 @@ import {
   playbackTime,
   followPlayhead,
   isPlaying,
+  mediaDuration,
+  stepPlayhead,
   scrubbing,
   zoomLevel,
   timelineScroll,
@@ -568,5 +570,44 @@ describe("followPlayhead (auto-select caption under playhead)", () => {
     expect(selectedCaptionIndex.value).toBeNull(); // stays deselected with no playhead move
     playbackTime.value = 0.6; // frame-step within caption 1 — no boundary crossing
     expect(selectedCaptionIndex.value).toBe(1); // re-asserted on the move
+  });
+});
+
+describe("stepPlayhead (frame-step, shared by the keys + transport)", () => {
+  // media-1 has fps 30; 3 captions running to 5.5s.
+  beforeEach(() => {
+    resetHistory(makeProject("step", 3));
+    selectedMediaId.value = "media-1";
+    mediaDuration.value = 5.5;
+    playbackTime.value = 1; // frame 30
+    isPlaying.value = true;
+  });
+  afterEach(() => { isPlaying.value = false; });
+
+  it("advances one frame and pauses", () => {
+    stepPlayhead(1);
+    expect(playbackTime.value).toBeCloseTo(1 + 1 / 30, 9);
+    expect(isPlaying.value).toBe(false);
+  });
+  it("steps back one frame", () => {
+    stepPlayhead(-1);
+    expect(playbackTime.value).toBeCloseTo(1 - 1 / 30, 9);
+  });
+  it("clamps at the start", () => {
+    playbackTime.value = 0;
+    stepPlayhead(-1);
+    expect(playbackTime.value).toBe(0);
+  });
+  it("clamps at the duration", () => {
+    playbackTime.value = 5.5;
+    stepPlayhead(1);
+    expect(playbackTime.value).toBe(5.5);
+  });
+  it("is a no-op with no usable duration", () => {
+    project.value = makeProject("empty", 0); // no captions
+    mediaDuration.value = 0;
+    playbackTime.value = 2;
+    stepPlayhead(1);
+    expect(playbackTime.value).toBe(2);
   });
 });

--- a/src/store/__tests__/app.test.ts
+++ b/src/store/__tests__/app.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import {
   project,
   isDirty,
@@ -7,6 +7,7 @@ import {
   selectedMedia,
   selectedCaption,
   playbackTime,
+  followPlayhead,
   isPlaying,
   scrubbing,
   zoomLevel,
@@ -523,5 +524,39 @@ describe("per-clip view persistence (settle effect, flush, active clip)", () => 
     expect(getActiveClip("/p.cod")).toBe("media-b");
     deselectAll();
     expect(getActiveClip("/p.cod")).toBeNull();
+  });
+});
+
+describe("followPlayhead (auto-select caption under playhead)", () => {
+  // captions at [0,1.5], [2,3.5], [4,5.5] — gaps at 1.5–2 and 3.5–4
+  beforeEach(() => {
+    project.value = makeProject("follow", 3);
+    selectedMediaId.value = "media-1";
+    selectedCaptionIndex.value = null;
+    playbackTime.value = 0;
+    followPlayhead.value = false;
+  });
+  // The follow effect is module-global; never let it leak into other suites.
+  afterEach(() => { followPlayhead.value = false; });
+
+  it("selects the caption under the playhead when on", () => {
+    followPlayhead.value = true;
+    playbackTime.value = 2.5; // inside caption 2
+    expect(selectedCaptionIndex.value).toBe(2);
+    playbackTime.value = 0.5; // inside caption 1
+    expect(selectedCaptionIndex.value).toBe(1);
+  });
+
+  it("keeps the selection through gaps instead of flickering to null", () => {
+    followPlayhead.value = true;
+    playbackTime.value = 0.5; // caption 1
+    expect(selectedCaptionIndex.value).toBe(1);
+    playbackTime.value = 1.7; // gap between captions 1 and 2
+    expect(selectedCaptionIndex.value).toBe(1);
+  });
+
+  it("does nothing when off", () => {
+    playbackTime.value = 2.5; // inside caption 2, but follow is off
+    expect(selectedCaptionIndex.value).toBeNull();
   });
 });

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -466,6 +466,21 @@ export const playingCaptionIndex = computed((): number | null => {
   return findCaptionAt(media.captions, time)?.index ?? null;
 });
 
+// "Follow playhead": when on, the active (selected) caption tracks the one under
+// the playhead — during playback, scrubbing, frame-step, region-jump. Persisted;
+// default off. Toggled from the transport bar.
+const storedFollow = localStorage.getItem("codfish:followPlayhead");
+export const followPlayhead = signal(storedFollow === "true");
+effect(() => {
+  // Mirror the caption under the playhead into the selection. Skips gaps
+  // (playingCaptionIndex null) so the selection doesn't flicker between captions.
+  // Reads only the two source signals (not selectedCaptionIndex), so writing the
+  // selection here can't re-trigger this effect.
+  if (followPlayhead.value && playingCaptionIndex.value != null) {
+    selectedCaptionIndex.value = playingCaptionIndex.value;
+  }
+});
+
 /** Validation warnings for the selected media's captions, grouped by caption
  * index. Cached: only re-runs validate() when captions, profile, or fps
  * changes — not on playback ticks or unrelated re-renders. Both Timeline and

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -5,6 +5,7 @@ import type { ExportFormat } from "../lib/export";
 import type { TranscriptionProgress } from "../lib/transcription";
 import { validate } from "../lib/pipeline/validate";
 import { findCaptionAt } from "../lib/pipeline";
+import { frameStep } from "../lib/playhead";
 import type { ValidationWarning } from "../lib/pipeline/types";
 import { SORT_MODES, SORT_DIRS, type SortMode, type SortDir } from "../lib/mediaSort";
 import { getClipView, rememberClipView, rememberActiveClip } from "../lib/clipView";
@@ -484,6 +485,19 @@ effect(() => {
     selectedCaptionIndex.value = playingCaptionIndex.value;
   }
 });
+
+/** Step the playhead one frame in `dir` (1 = forward, -1 = back) and pause —
+ *  the shared action behind the Left/Right keys and the transport's frame-step
+ *  buttons. No-op without a usable fps and duration. */
+export function stepPlayhead(dir: 1 | -1): void {
+  const m = selectedMedia.peek();
+  const f = m?.fps ?? activeProfile.peek().timing.defaultFps;
+  const dur = mediaDuration.peek() || (m?.captions.length ? m.captions[m.captions.length - 1].end : 0);
+  if (!f || !dur) return;
+  isPlaying.value = false; // stepping is a paused review action
+  const next = frameStep(playbackTime.peek(), f, dir);
+  playbackTime.value = Math.max(0, Math.min(dur, next));
+}
 
 /** Validation warnings for the selected media's captions, grouped by caption
  * index. Cached: only re-runs validate() when captions, profile, or fps

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -468,7 +468,7 @@ export const playingCaptionIndex = computed((): number | null => {
 
 // "Follow playhead": when on, the active (selected) caption tracks the one under
 // the playhead — during playback, scrubbing, frame-step, region-jump. Persisted;
-// default off. Toggled from the transport bar.
+// default off. Toggled from the timeline toolbar.
 const storedFollow = localStorage.getItem("codfish:followPlayhead");
 export const followPlayhead = signal(storedFollow === "true");
 effect(() => {

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -76,6 +76,10 @@ export const mediaDuration = signal(0);  // seconds — set from loadedmetadata
 // persist effect below skip the continuous drag and fire once on release — when
 // the playhead has "landed somewhere" — instead of writing on every pointermove.
 export const scrubbing = signal(false);
+// Bumped when a caption is clicked in the captions panel, to ask the timeline to
+// scroll that caption into view — even when it's already the active one (its start
+// already the playhead), which wouldn't otherwise change any signal.
+export const revealCaptionTick = signal(0);
 // Timeline zoom (1 = Fit … 500). Lives here (not in Timeline) so it's part of the
 // per-clip view memory: remembered per clip and restored on switch, like the
 // playhead. The persist effect reads it via peek so a Ctrl-wheel zoom gesture

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -472,10 +472,14 @@ export const playingCaptionIndex = computed((): number | null => {
 const storedFollow = localStorage.getItem("codfish:followPlayhead");
 export const followPlayhead = signal(storedFollow === "true");
 effect(() => {
-  // Mirror the caption under the playhead into the selection. Skips gaps
-  // (playingCaptionIndex null) so the selection doesn't flicker between captions.
-  // Reads only the two source signals (not selectedCaptionIndex), so writing the
-  // selection here can't re-trigger this effect.
+  // Mirror the caption under the playhead into the selection. Subscribe to
+  // playbackTime directly so this re-asserts on EVERY playhead move, not only
+  // when the caption under it changes: after a manual deselect with the playhead
+  // parked inside a caption, a within-caption scrub/frame-step doesn't change
+  // playingCaptionIndex, so without this the caption would never re-select. Skips
+  // gaps (playingCaptionIndex null) so the selection doesn't flicker between
+  // captions. Reads no selection signal, so writing it here can't re-trigger this.
+  void playbackTime.value;
   if (followPlayhead.value && playingCaptionIndex.value != null) {
     selectedCaptionIndex.value = playingCaptionIndex.value;
   }

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -1440,6 +1440,13 @@ body.rows-dragging * {
   position: relative;
   background: var(--tl-surface);
   border-bottom: 1px solid var(--tl-border);
+  /* Clip the playhead's 1px line + round handle at the row's left/right edges so
+     parking the playhead at the very end doesn't add a few px of horizontal
+     overflow — which, at fit zoom, surfaces a stray scrollbar. `clip` (not
+     `hidden`) so the row doesn't become a scroll container and break the
+     position:sticky waveform canvas; overflow-y stays visible so the handle can
+     still poke above the row. */
+  overflow-x: clip;
 }
 
 /* Sticks to the visible window while the full-width row scrolls

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -1591,10 +1591,14 @@ body.rows-dragging * {
 .timeline-block--selected {
   background: var(--tl-caption-block-selected);
   border-color: rgba(255,255,255,0.3);
+  /* Lift above neighbouring blocks so the selection (and playing) outline isn't
+     painted over by the next block — they're absolutely positioned siblings. */
+  z-index: 1;
 }
 
 .timeline-block--playing {
   box-shadow: 0 0 0 1px var(--color-playing-border), 0 0 8px 3px color-mix(in srgb, var(--color-playing-border) 40%, transparent);
+  z-index: 2;
 }
 
 .timeline-block-label {

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -998,6 +998,36 @@ body.rows-dragging * {
   position: relative;
 }
 
+/* Center column = the video preview with the playback transport docked beneath
+   it. The column carries the left/right dividers the panels used to draw via
+   `.panel + .panel`, since the wrapper itself isn't a .panel. */
+.video-column {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+  border-left: 1px solid var(--color-border);
+  border-right: 1px solid var(--color-border);
+}
+.video-column > .video-panel {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+/* Playback-only strip under the video: go to start, frame-step, play/pause.
+   Timeline-view tools live in the timeline toolbar, not here. */
+.transport-bar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  flex: 0 0 auto;
+  height: 40px;
+  padding: 0 var(--space-3);
+  border-top: 1px solid var(--color-border);
+  background: var(--color-surface);
+}
+
 .video-container {
   display: flex;
   align-items: center;
@@ -1269,7 +1299,7 @@ body.rows-dragging * {
   overflow: hidden;
 }
 
-.timeline-transport {
+.timeline-toolbar {
   display: flex;
   align-items: center;
   gap: var(--space-2);
@@ -1340,7 +1370,7 @@ body.rows-dragging * {
 }
 
 /* Pushes the right-aligned tool group (snap, waveform style, zoom) to the far
-   edge of the transport bar, so the timecode + fps stay grouped on the left. */
+   edge of the timeline toolbar, so the timecode + fps stay grouped on the left. */
 .timeline-tools-start {
   margin-left: auto;
 }

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -1497,6 +1497,7 @@ body.rows-dragging * {
   border-bottom: 1px solid var(--tl-border);
   overflow: hidden;
   user-select: none;
+  cursor: pointer; /* click/drag to seek, like the waveform below */
 }
 
 .timeline-ruler-tick {
@@ -1547,7 +1548,7 @@ body.rows-dragging * {
 .timeline-playhead::before {
   content: "";
   position: absolute;
-  top: -4px;
+  top: -9px;
   left: -4px;
   width: 9px;
   height: 9px;

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -1324,12 +1324,10 @@ body.rows-dragging * {
 }
 
 .timeline-fps-badge {
-  margin-left: auto;
   font-family: var(--font-mono);
   font-size: var(--text-xs);
   color: var(--tl-text-secondary);
   user-select: none;
-  padding-right: var(--space-2);
 }
 
 .timeline-fps-badge--default {
@@ -1339,6 +1337,12 @@ body.rows-dragging * {
 
 .timeline-fps-badge--vfr {
   color: var(--color-warning, #e5a100);
+}
+
+/* Pushes the right-aligned tool group (snap, waveform style, zoom) to the far
+   edge of the transport bar, so the timecode + fps stay grouped on the left. */
+.timeline-tools-start {
+  margin-left: auto;
 }
 
 .timeline-btn--timecode {

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -1363,6 +1363,9 @@ body.rows-dragging * {
   display: flex;
   flex-direction: column;
   min-height: 0;
+  /* Kill the macOS rubber-band/overshoot — it's disorienting on a timeline and
+     fights precise scrubbing. Also stops the scroll chaining to ancestors. */
+  overscroll-behavior-x: none;
 }
 
 .timeline-scroll-outer::-webkit-scrollbar {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -68,8 +68,7 @@
   --tl-border: #2a2a2a;
   --tl-text: #e0e0e0;
   --tl-text-secondary: #606060;
-  --tl-waveform: #2d5a3d;
-  --tl-waveform-progress: #3d7a52;
+  --tl-waveform: #374151;
   --tl-caption-block: #1a4530;
   --tl-caption-block-selected: #4a9e6a;
   --tl-caption-block-text: #e0e0e0;
@@ -110,7 +109,19 @@
   --color-playing-bg: #eff6ff;
   --color-playing-border: #3b82f6;
 
-  /* Timeline stays dark regardless of theme */
+  /* Timeline — light counterparts of the :root (dark) values above */
+  --tl-bg: #ececec;
+  --tl-surface: #f5f5f5;
+  --tl-border: #dcdcdc;
+  --tl-text: #1c1c1c;
+  --tl-text-secondary: #6b6b6b;
+  --tl-waveform: #374151;
+  --tl-caption-block: #cdeed8;
+  --tl-caption-block-selected: #4a9e6a;
+  --tl-caption-block-text: #16331f;
+  --tl-playhead: #fbbf24;
+  --tl-grid: #e2e2e2;
+  --tl-scrubber: #e8e8e8;
 
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
   --shadow-md: 0 2px 8px rgba(0, 0, 0, 0.10);


### PR DESCRIPTION
# Timeline: navigation, editing, and transport improvements

A cohesive pass over the timeline — a relocated transport, frame-accurate keyboard editing (trim + rolling edits), better scrubbing/scroll feel, a continuous waveform style, and a light theme — plus the supporting pure-logic extraction and tests.

**15 commits since `v0.6.7` · 13 files · +1009 / −113 · 726 tests green (tsc + build clean).**

## Highlights

### Transport & playback
- **Playback transport moved to its own strip under the video** (`⏮ · |◀ · ▶/⏸ · ▶| · ⏭`): go-to-start, frame-step, play/pause, go-to-end. The timeline keeps a tools-only toolbar — timecode/fps on the left; snap, follow, waveform, zoom on the right.
- **Frame-accurate seeking** — seeks to the middle of the target frame, so stepping lands on the intended frame instead of the decoder resolving N−1/N at random.
- **Frame-step** — `←`/`→` (and the new transport buttons) step one frame, paused.

### Editing — trim & rolling
- **Trim in/out to playhead** — `[` / `]` set the selected caption's in/out edge to the playhead (frame-snapped, clamped to neighbours, single undo).
- **Rolling edit** — `Shift+[` / `Shift+]` and **Shift-drag** a shared-boundary handle move the cut between two adjacent captions, both edges together.
- **Resize/roll drags no longer move the playhead** or flip selection at random — a drag deterministically selects the caption you grabbed and leaves the playhead put (fixes an intermittent post-drag synthetic-click leak).

### Navigation & scrubbing
- **Region-jump** — `↑` / `↓` to the next/previous boundary (caption edges + clip ends), paused.
- **Follow playhead** (toggle) — auto-select the caption under the playhead; re-asserts on every move, so it recovers after a manual deselect.
- **Follow-on-seek auto-scroll** + **edge-pan while scrubbing**.
- **Zoom on bare `+`/`-`** (no modifier; `Ctrl/Cmd`+scroll still zooms).
- **macOS scroll rubber-band** suppressed.

### Waveform & theme
- **Continuous-envelope waveform style** + a toggle (vs. bars); waveform colour driven by a CSS variable; scale/draw fixes.
- **Light theme** for the timeline; selection / playing / playhead **z-index** ordering.

## Notable behavior changes
- Zoom keys no longer require `Ctrl/Cmd` (the modifier still works and still blocks the WebView page-zoom).
- With **follow-playhead ON**, selection tracks the playhead on every move — so it can override a just-restored selection on undo/redo or a clip switch. Accepted as consistent with "selection follows the playhead." (Off by default.)
- A resize-handle click no longer seeks the playhead (it selects only).

## Architecture
- **`lib/playhead.ts`** (new) — pure, tested frame/edit math: `frameStep`, `frameMidpoint`, `nextBoundary`, `clampStart/End`, `computeTrim`, `computeRoll`.
- **`stepPlayhead`** store action — one shared frame-step path for the keys and the transport buttons.
- **`TransportBar`** component; **`.video-column`** wrapper (carries the panel dividers).
- **`lib/waveform.ts`** — the painter's bin→column math extracted into pure helpers (`computePeakMax`, `continuousBinRange`, `reduceColumns`) + tests.

## Testing
- **726 unit tests** (vitest), `tsc --noEmit`, and `vite build` all green.
- New pure logic is unit-tested: the playhead helpers (frame math, trim, roll — incl. fractional fps), `stepPlayhead`, the `followPlayhead` re-assert, and the waveform reduction.
- Ran an adversarial multi-agent pre-merge review over the full branch (logic, waveform, drag, nav/seek, state, layout, integration): **0 blockers, 0 regressions** — findings were nits / known edge-cases.

## Compatibility
- **`.cod` format unchanged** — no new persisted fields; existing projects open as-is.
- **fps / VFR** — caption times are stored in seconds (fps-agnostic). Millisecond exports (SRT/VTT) are exact regardless of fps/VFR; SMPTE/frame exports quantize to the export fps (`media.fps ?? profile default`) via a monotonic floor (no overlap inversion). VFR SMPTE stays approximate (single nominal fps) — unchanged by this branch.

## Deferred (not in this PR)
- **J-K-L shuttle** — gated on a player backend that can play in reverse (HTML5 `<video>` can't).
- **Custom keyboard shortcuts** — and, as its phase 1, consolidating the three document-level keydown handlers behind one `isTypingTarget()` gate.
- **Caption import** (SRT/VTT) must run `enforceTiming` so imported edges are frame-aligned like generated ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)